### PR TITLE
Expose drupalorg executable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
             "name": "Matt Glaman",
             "email": "nmd.matt@gmail.com"
         }
+    ],
+    "bin": [
+      "drupalorg"
     ]
 }


### PR DESCRIPTION
The ``drupalorg`` executable should be exposed via composers bin property. This makes the installation via ``composer global require mglaman/drupalorg-cli`` possible.