### PR TITLE
ReleaseNotes should properly ignore commits it can't read

### DIFF
--- a/src/Cli/Command/Maintainer/ReleaseNotes.php
+++ b/src/Cli/Command/Maintainer/ReleaseNotes.php
@@ -108,12 +108,15 @@ class ReleaseNotes extends Command
     foreach ($changes as $change) {
       $nidsMatches = [];
       preg_match('/#(\d+)/S', $change, $nidsMatches);
-      $this->nids[] = $nidsMatches[1];
 
-      $issue = $this->getNode($nidsMatches[1]);
-      $issueCategory = $issue->get('field_issue_category');
-      $issueCategoryLabel = $this->categoryLabelMap[$issueCategory];
-      $processedChanges[$issueCategoryLabel][$nidsMatches[1]] = $this->formatLine($change, $format);
+      if(isset($nidsMatches[1])) {
+        $this->nids[] = $nidsMatches[1];
+
+        $issue = $this->getNode($nidsMatches[1]);
+        $issueCategory = $issue->get('field_issue_category');
+        $issueCategoryLabel = $this->categoryLabelMap[$issueCategory];
+        $processedChanges[$issueCategoryLabel][$nidsMatches[1]] = $this->formatLine($change, $format);
+      }
     }
     ksort($processedChanges);
 


### PR DESCRIPTION
Small change so it correctly ignores non issue credit tagged commits, such as merges or non tagged commits. Otherwise it will throw notices and the counts will be off.