### PR TITLE
Add issue:interdiff command

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -42,6 +42,7 @@ class Application extends ParentApplication
         $commands[] = new Command\Issue\Link();
         $commands[] = new Command\Issue\Branch();
         $commands[] = new Command\Issue\Patch();
+        $commands[] = new Command\Issue\Interdiff();
         $commands[] = new Command\Issue\Apply();
         $commands[] = new Command\Project\Link();
         $commands[] = new Command\Project\Kanban();

--- a/src/Cli/Command/Issue/Interdiff.php
+++ b/src/Cli/Command/Issue/Interdiff.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace mglaman\DrupalOrgCli\Command\Issue;
+
+use Gitter\Client;
+use mglaman\DrupalOrg\RawResponse;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+/**
+ * Command to generate an interdiff text file for an issue.
+ */
+class Interdiff extends IssueCommandBase {
+
+  /**
+   * The git repository.
+   *
+   * @var \Gitter\Repository
+   */
+  protected $repository;
+
+  /**
+   * The current working directory.
+   *
+   * @var string
+   */
+  protected $cwd;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure() {
+    $this
+      ->setName('issue:interdiff')
+      ->addArgument('nid', InputArgument::REQUIRED, 'The issue node ID')
+      ->setDescription('Generate an interdiff for the issue from local changes.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function initialize(InputInterface $input, OutputInterface $output) {
+    parent::initialize($input, $output);
+    $this->cwd = getcwd();
+    try {
+      $client = new Client();
+      $this->repository = $client->getRepository($this->cwd);
+    }
+    catch (\Exception $e) {
+      $this->repository = NULL;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $nid = $this->stdIn->getArgument('nid');
+    $issue = $this->getNode($nid);
+
+    if (!$this->checkBranch($issue)) {
+      return;
+    }
+
+    $issue_version_branch = $this->getIssueVersionBranchName($issue);
+    if (!$this->repository->hasBranch($issue_version_branch)) {
+      $this->stdErr->writeln("Issue branch $issue_version_branch does not exist locally.");
+    }
+
+    // Create a diff from the first commit of the issue branch.
+    $first_issue_branch_commit = sprintf('$(git log %s..HEAD --format=%%H)', $issue_version_branch);
+    $process = new Process(sprintf('git diff %s', $first_issue_branch_commit));
+    $process->run();
+
+    $filename = $this->cwd . DIRECTORY_SEPARATOR . $this->buildInterdiffName($issue);
+    file_put_contents($filename, $process->getOutput());
+    $this->stdOut->writeln("<comment>Interdiff written to {$filename}</comment>");
+
+    $process = new Process(sprintf('git diff %s --stat', $first_issue_branch_commit));
+    $process->setTty(TRUE);
+    $process->run();
+    $this->stdOut->write($process->getOutput());
+  }
+
+  /**
+   * Generates a file name for an interdiff.
+   *
+   * @param \mglaman\DrupalOrg\RawResponse $issue
+   *   The issue raw response.
+   *
+   * @return string
+   *   The name of the interdiff file.
+   */
+  protected function buildInterdiffName(RawResponse $issue) {
+    $comment_count = $issue->get('comment_count');
+    return sprintf('interdiff-%s-%s-%s.txt', $issue->get('nid'), $comment_count, $comment_count + 1);
+  }
+
+  /**
+   * Checks that the user is working on an issue branch.
+   *
+   * @param \mglaman\DrupalOrg\RawResponse $issue
+   *   The issue raw response.
+   *
+   * @return bool
+   *   Whether or not user is working on an issue branch.
+   */
+  protected function checkBranch(RawResponse $issue) {
+    $issueVersion = $issue->get('field_issue_version');
+    if (strpos($issueVersion, $this->repository->getCurrentBranch()) !== FALSE) {
+      $this->stdOut->writeln("<comment>You do not appear to be working on an issue branch.</comment>");
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
Running the command:
```
$ drupalorg issue:interdiff 2809177
Interdiff written to /var/www/drupal8/interdiff-2809177-62-63.txt
 core/CHANGELOG.txt | 2 ++
 1 file changed, 2 insertions(+)
```

Contents of the generated file:
```
$ cat interdiff-2809177-62-63.txt 
diff --git a/core/CHANGELOG.txt b/core/CHANGELOG.txt
index 59c2953..06926d2 100644
--- a/core/CHANGELOG.txt
+++ b/core/CHANGELOG.txt
@@ -6,3 +6,5 @@ Drupal 8 release cycle: https://www.drupal.org/core/release-cycle-overview
  https://www.drupal.org/8/download
 * API change records for Drupal core:
  https://www.drupal.org/list-changes/drupal
+
+asdfasdf
```
