### PR TITLE
Remove the --no-prefix flag for the `issue:patch` git command.

### DIFF
--- a/src/Cli/Command/Issue/Patch.php
+++ b/src/Cli/Command/Issue/Patch.php
@@ -57,7 +57,7 @@ class Patch extends IssueCommandBase {
 
       // Create a diff from our merge-base commit.
       $merge_base_cmd = sprintf('$(git merge-base %s HEAD)', $issue_version_branch);
-      $process = new Process(sprintf('git diff --no-prefix --no-ext-diff %s HEAD', $merge_base_cmd));
+      $process = new Process(sprintf('git diff --no-ext-diff %s HEAD', $merge_base_cmd));
       $process->run();
 
       $filename = $this->cwd . DIRECTORY_SEPARATOR . $patchName;


### PR DESCRIPTION
- The `--no-prefix` flag removes the prepended `a` and `b` lines which
  Drupal.org didn't used to require, but appears to now require.