### PR TITLE
Correcting version number

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Command\HelpCommand;
 
 class Application extends ParentApplication
 {
-    const VERSION = '0.0.9';
+    const VERSION = '0.1.1';
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Maybe little value in fixing the version number now as only people installing from Git / dev will benefit. It was just a little bit confusing to get to 0.0.9 as version after downloading the phar file for release 0.1.1. 

Nice tool by the way, I installed it in 2018, but haven't started to use it properly before now.