### PR TITLE
Bash completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Use the following command to install the command line tool via Composer:
 
 `composer global require mglaman/drupalorg-cli`
 
+### Installing (Bash) completion
+
+`drupalorg` comes with completion support for all commands, excluding options.
+
+To activate it, either source the completion file or add it to the system-wide completion directory, normally `/etc/bash_completion.d/`.
+
+In your `.bashrc` (or `.profile`) add
+
+```
+source [...]/vendor/mglaman/drupalorg-cli/drupalorg-cli-completion.sh
+```
+
 ## Updating
 
 Automatic updating is not yet supported. You will need to manually download new releases.

--- a/drupalorg-cli-completion.sh
+++ b/drupalorg-cli-completion.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+_drupalorgcli_complete() {
+    local cur prev words cword command
+    _init_completion -n : || return
+
+    # This is a minimal completion - global options and options for each command is not completed.
+    # Many edge cases are not covered, for example completion after command option is wrong.
+
+    COMPREPLY=()
+
+    # Stop completing if command is already present, except for "help".
+    # (This check fails when options follows command.)
+    if [[ -n $prev ]] && [[ $prev != "help" ]]; then
+        command=$(compgen -W "$(drupalorg complete)" -- "$prev")
+        if [[ $command == $prev ]]; then
+            return 0
+        fi
+    fi
+
+    COMPREPLY=( $(compgen -W "$(drupalorg complete)" -- "$cur") )
+    __ltrim_colon_completions "$cur"
+} &&
+complete -F _drupalorgcli_complete drupalorg

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -41,6 +41,7 @@ class Application extends ParentApplication
         }
 
         $commands[] = new Command\CacheClear();
+        $commands[] = new Command\Completion();
         $commands[] = new Command\DrupalCi\ListResults();
         $commands[] = new Command\DrupalCi\Watch();
         $commands[] = new Command\Issue\Link();

--- a/src/Cli/Command/Completion.php
+++ b/src/Cli/Command/Completion.php
@@ -23,22 +23,22 @@ class Completion extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-      $command = $this->getApplication()->find('list');
+        $command = $this->getApplication()->find('list');
 
-      $arguments = [
-        '--format' => 'json'
-      ];
-      $input = new ArrayInput($arguments);
-      $output = new BufferedOutput();
-      $returnCode = $command->run($input, $output);
-      $commandListArray = json_decode($output->fetch(), true);
-      $commandsToComplete = [];
-      foreach ($commandListArray['commands'] as $command) {
-          if ($command['name'] == $this->getName()) {
-              continue;
-          }
-          $commandsToComplete[] = $command['name'];
-      }
-      $this->stdOut->writeln(implode(' ', $commandsToComplete));
+        $arguments = [
+            '--format' => 'json'
+        ];
+        $input = new ArrayInput($arguments);
+        $output = new BufferedOutput();
+        $returnCode = $command->run($input, $output);
+        $commandListArray = json_decode($output->fetch(), true);
+        $commandsToComplete = [];
+        foreach ($commandListArray['commands'] as $commandToAdd) {
+            if ($commandToAdd['name'] == $this->getName()) {
+                continue;
+            }
+            $commandsToComplete[] = $commandToAdd['name'];
+        }
+        $this->stdOut->writeln(implode(' ', $commandsToComplete));
     }
 }

--- a/src/Cli/Command/Completion.php
+++ b/src/Cli/Command/Completion.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace mglaman\DrupalOrgCli\Command;
+
+use mglaman\DrupalOrgCli\Cache;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Completion extends Command
+{
+    protected function configure()
+    {
+        $this
+          ->setName('complete')
+          ->setDescription('List commands for (Bash) completion');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+      $command = $this->getApplication()->find('list');
+
+      $arguments = [
+        '--format' => 'json'
+      ];
+      $input = new ArrayInput($arguments);
+      $output = new BufferedOutput();
+      $returnCode = $command->run($input, $output);
+      $commandListArray = json_decode($output->fetch(), true);
+      $commandsToComplete = [];
+      foreach ($commandListArray['commands'] as $command) {
+          if ($command['name'] == $this->getName()) {
+              continue;
+          }
+          $commandsToComplete[] = $command['name'];
+      }
+      $this->stdOut->writeln(implode(' ', $commandsToComplete));
+    }
+}


### PR DESCRIPTION
This is a minimal implementation which only completes the actual commands. However, new commands are automatically available for completion - no hard-coded list of command names are used. And supporting global options is easy, but handling options for each command is more work. 

I was planning to add instructions to the README about sourcing drupalorg-cli-completion.sh (or adding/linking it to `/etc/bash_completion.d/` but that file might not be available when installing as phar? Hm. Maybe we should do as the Github shell -  ref `gh completion --shell bash` - add a command that just echos the file so it works for phar installs too? I'm using cgr for Composer installation so I didn't think about this problem before now ...

It should be noted that the package  stecman/symfony-console-completion provides "automatic tab-key completion for Symfony console application options, arguments and parameters" but I think it's bloated for our need.

And finally: I'm not using Zsh so I haven't tried to support it, but it might not be much work.

PS! Creating this patch took me longer than anticipated because of the colons in the commands names - colons are breakwords in Bash. The solution was easy enough.