### PR TITLE
Add help text for the apply and branch issue commands.

### DIFF
--- a/src/Cli/Command/Issue/Apply.php
+++ b/src/Cli/Command/Issue/Apply.php
@@ -12,9 +12,9 @@ use Symfony\Component\Process\Process;
 class Apply extends IssueCommandBase
 {
 
-  /**
-   * @var \Gitter\Repository
-   */
+    /**
+     * @var \Gitter\Repository
+     */
     protected $repository;
 
     protected $cwd;
@@ -24,13 +24,17 @@ class Apply extends IssueCommandBase
         $this
         ->setName('issue:apply')
         ->addArgument('nid', InputArgument::REQUIRED, 'The issue node ID')
-        ->setDescription('Applies the latest patch from an issue.');
+        ->setDescription('Applies the latest patch from an issue.')
+        ->setHelp(implode(PHP_EOL, [
+            'This command applies the latest patch from an issue.',
+            'Before applying the patch, an issue branch for the patch will be checked out.',
+            'If the branch doesn\'t exist, it will be created.',]));
     }
 
-  /**
-   * {@inheritdoc}
-   *
-   */
+    /**
+     * {@inheritdoc}
+     *
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $nid = $this->stdIn->getArgument('nid');
@@ -56,16 +60,16 @@ class Apply extends IssueCommandBase
 
     protected function applyWithGit($issue, $patchFileName)
     {
-      // Validate the issue versions branch, create or checkout issue branch.
+        // Validate the issue versions branch, create or checkout issue branch.
         $issueBranchCommand = $this->getApplication()->find('issue:branch');
         $issueBranchCommand->run($this->stdIn, $this->stdOut);
 
         $branchName = $this->buildBranchName($issue);
         $tempBranchName = $branchName . '-patch-temp';
 
-      // Check out the root development branch to create a temporary merge branch
-      // where we will apply the patch, and then three way merge to existing issue
-      // branch.
+        // Check out the root development branch to create a temporary merge branch
+        // where we will apply the patch, and then three way merge to existing issue
+        // branch.
         $issueVersionBranch = $this->getIssueVersionBranchName($issue);
         $this->repository->checkout($issueVersionBranch);
         $this->stdOut->writeln(sprintf('<comment>%s</comment>', "Creating temp branch $tempBranchName"));
@@ -81,7 +85,7 @@ class Apply extends IssueCommandBase
         $this->stdOut->writeln(sprintf('<comment>%s</comment>', "Committing $patchFileName"));
         $this->repository->commit($patchFileName);
 
-      // Check out existing issue branch for three way merge.
+        // Check out existing issue branch for three way merge.
         $this->stdOut->writeln(sprintf('<comment>%s</comment>', "Checking out $branchName and merging"));
         $this->repository->checkout($branchName);
         $merge = $this->runProcess(sprintf('git merge %s --strategy recursive -X theirs', $tempBranchName));

--- a/src/Cli/Command/Issue/Branch.php
+++ b/src/Cli/Command/Issue/Branch.php
@@ -23,8 +23,12 @@ class Branch extends IssueCommandBase
         $this
         ->setName('issue:branch')
         ->addArgument('nid', InputArgument::REQUIRED, 'The issue node ID')
-        ->setDescription('Creates a branch for the issue.');
-    }
+        ->setDescription('Creates a branch for the issue.')
+        ->setHelp(implode(PHP_EOL, [
+            'This command creates a branch for the issue.',
+            'If there is an existing patch in the issue queue, that you want to apply,',
+            'it is quicker to use the \'issue:apply\' command instead.']));
+   }
 
   /**
    * {@inheritdoc}

--- a/src/Cli/Command/Issue/Branch.php
+++ b/src/Cli/Command/Issue/Branch.php
@@ -11,9 +11,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Branch extends IssueCommandBase
 {
 
-  /**
-   * @var \Gitter\Repository
-   */
+    /**
+     * @var \Gitter\Repository
+     */
     protected $repository;
 
     protected $cwd;
@@ -28,12 +28,12 @@ class Branch extends IssueCommandBase
             'This command creates a branch for the issue.',
             'If there is an existing patch in the issue queue, that you want to apply,',
             'it is quicker to use the \'issue:apply\' command instead.']));
-   }
+    }
 
-  /**
-   * {@inheritdoc}
-   *
-   */
+    /**
+     * {@inheritdoc}
+     *
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $issue = $this->getNode($this->nid);

--- a/src/Cli/Command/Issue/Interdiff.php
+++ b/src/Cli/Command/Issue/Interdiff.php
@@ -15,20 +15,20 @@ use Symfony\Component\Process\Process;
 class Interdiff extends IssueCommandBase
 {
 
-  /**
-   * {@inheritdoc}
-   */
+    /**
+     * {@inheritdoc}
+     */
     protected function configure()
     {
         $this
         ->setName('issue:interdiff')
         ->addArgument('nid', InputArgument::OPTIONAL, 'The issue node ID')
-        ->setDescription('Generate an interdiff for the issue from local changes.');
+        ->setDescription('Generate an interdiff for the issue from committed local changes.');
     }
 
-  /**
-   * {@inheritdoc}
-   */
+    /**
+     * {@inheritdoc}
+     */
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
         parent::initialize($input, $output);
@@ -38,9 +38,9 @@ class Interdiff extends IssueCommandBase
         }
     }
 
-  /**
-   * {@inheritdoc}
-   */
+    /**
+     * {@inheritdoc}
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $issue = $this->getNode($this->nid);
@@ -55,7 +55,7 @@ class Interdiff extends IssueCommandBase
             exit(1);
         }
 
-      // Find the two last commits on the issue branch.
+        // Find the two last commits on the issue branch.
         $process = new Process(sprintf('git log -2 %s..HEAD --format=%%H', $issue_version_branch));
         $process->run();
         $last_issue_branch_commits = explode(PHP_EOL, $process->getOutput());
@@ -65,7 +65,7 @@ class Interdiff extends IssueCommandBase
             exit(1);
         }
 
-      // Create a diff between two last commits of the issue branch. (Reverse order of output from "git log".)
+        // Create a diff between two last commits of the issue branch. (Reverse order of output from "git log".)
         $diff_cmd = sprintf('git diff %s', implode(" ", array_reverse($last_issue_branch_commits)));
         $process = new Process($diff_cmd);
         $process->run();
@@ -79,15 +79,15 @@ class Interdiff extends IssueCommandBase
         $this->stdOut->write($process->getOutput());
     }
 
-  /**
-   * Generates a file name for an interdiff.
-   *
-   * @param \mglaman\DrupalOrg\RawResponse $issue
-   *   The issue raw response.
-   *
-   * @return string
-   *   The name of the interdiff file.
-   */
+    /**
+     * Generates a file name for an interdiff.
+     *
+     * @param \mglaman\DrupalOrg\RawResponse $issue
+     *   The issue raw response.
+     *
+     * @return string
+     *   The name of the interdiff file.
+     */
     protected function buildInterdiffName(RawResponse $issue)
     {
         $comment_count = $issue->get('comment_count');
@@ -95,33 +95,33 @@ class Interdiff extends IssueCommandBase
         return sprintf('interdiff-%s-%s-%s.txt', $issue->get('nid'), $last_comment_with_patch, $comment_count + 1);
     }
 
-  /**
-   * Finds the last comment with a patch.
-   *
-   * @param \mglaman\DrupalOrg\RawResponse $issue
-   *   The issue raw response.
-   *
-   * @return int
-   *   The comment index number.
-   */
+    /**
+     * Finds the last comment with a patch.
+     *
+     * @param \mglaman\DrupalOrg\RawResponse $issue
+     *   The issue raw response.
+     *
+     * @return int
+     *   The comment index number.
+     */
     protected function getLastCommentWithPatch(RawResponse $issue)
     {
-      // Files have the relevant CID info, but we need to calculate the actual
-      // comment index based on that.
+        // Files have the relevant CID info, but we need to calculate the actual
+        // comment index based on that.
         $comment_index = $this->getCommentIndex($issue);
         $cid = $this->getLatestFileCid($issue);
         return $comment_index[$cid] ?? 1;
     }
 
-  /**
-   * Builds an index of comments, starting with 1, keyed by CID.
-   *
-   * @param \mglaman\DrupalOrg\RawResponse $issue
-   *   The issue raw response.
-   *
-   * @return array
-   *   Array of comment index numbers, indexed by comment ID.
-   */
+    /**
+     * Builds an index of comments, starting with 1, keyed by CID.
+     *
+     * @param \mglaman\DrupalOrg\RawResponse $issue
+     *   The issue raw response.
+     *
+     * @return array
+     *   Array of comment index numbers, indexed by comment ID.
+     */
     protected function getCommentIndex(RawResponse $issue)
     {
         $comment_index = [];
@@ -131,15 +131,15 @@ class Interdiff extends IssueCommandBase
         return $comment_index;
     }
 
-  /**
-   * Gets the most recent patch file from the issue.
-   *
-   * @param \mglaman\DrupalOrg\RawResponse $issue
-   *   The issue raw response.
-   *
-   * @return int
-   *   The most recent patch file's associated comment ID from the issue.
-   */
+    /**
+     * Gets the most recent patch file from the issue.
+     *
+     * @param \mglaman\DrupalOrg\RawResponse $issue
+     *   The issue raw response.
+     *
+     * @return int
+     *   The most recent patch file's associated comment ID from the issue.
+     */
     protected function getLatestFileCid(RawResponse $issue)
     {
         $latestPatch = $this->getLatestFile($issue);
@@ -151,15 +151,15 @@ class Interdiff extends IssueCommandBase
         return $file->file->cid ?? 0;
     }
 
-  /**
-   * Checks that the user is working on an issue branch.
-   *
-   * @param \mglaman\DrupalOrg\RawResponse $issue
-   *   The issue raw response.
-   *
-   * @return bool
-   *   Whether or not user is working on an issue branch.
-   */
+    /**
+     * Checks that the user is working on an issue branch.
+     *
+     * @param \mglaman\DrupalOrg\RawResponse $issue
+     *   The issue raw response.
+     *
+     * @return bool
+     *   Whether or not user is working on an issue branch.
+     */
     protected function checkBranch(RawResponse $issue)
     {
         $issueVersion = $issue->get('field_issue_version');


### PR DESCRIPTION
I think these additions to the command documentation is helpful. It's not obvious that "apply" automatically creates the branch (unless you read the source code). And "branch" is really only useful when there are no existing patches.

Also fixes some whitespace discussed earlier.

Yeah, I know I shouldn't mix whitespace changes with real changes - sorry. ("git show -w" to the rescue.)