### PR TITLE
Add an issue:show command

### DIFF
--- a/src/Api/IssueTrait.php
+++ b/src/Api/IssueTrait.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace mglaman\DrupalOrg;
+
+trait IssueTrait
+{
+    /**
+     * Produces the label for a given category id.
+     *
+     * @param int $value
+     *   Category identifier.
+     *
+     * @return string
+     *   The label if known, or the casted string value if not.
+     */
+    public function getIssueCategoryLabel(int $value): string {
+        switch ($value) {
+            case 1:
+                return 'Bug report';
+            case 2:
+                return 'Task';
+            case 3:
+                return 'Feature request';
+            case 4:
+                return 'Support request';
+            case 5:
+                return 'Plan';
+            default:
+                return (string)$value;
+        }
+    }
+
+    /**
+     * Produces the label for a given priority id.
+     *
+     * @param int $value
+     *   Priority identifier.
+     *
+     * @return string
+     *   The label if known, or the casted string value if not.
+     */
+    public function getIssuePriorityLabel(int $value): string {
+        switch ($value) {
+            case 100:
+                return 'Minor';
+            case 200:
+                return 'Normal';
+            case 300:
+                return 'Major';
+            case 400:
+                return 'Critical';
+            default:
+                return (string)$value;
+        }
+    }
+
+    /**
+     * Produces the label for a given status id.
+     *
+     * @param int $value
+     *   Status identifier.
+     *
+     * @return string
+     *   The label if known, or the casted string value if not.
+     */
+    public function getIssueStatusLabel(int $value): string {
+        switch ($value) {
+            case 1:
+                return 'Active';
+            case 2:
+                return 'Fixed';
+            case 13:
+                return 'Needs Work';
+            case 8:
+                return 'Needs Review';
+            case 16:
+                return 'Postponed [NMI]';
+            case 14:
+                return 'RTBC';
+            default:
+                return (string)$value;
+        }
+    }
+}

--- a/src/Api/IssueTrait.php
+++ b/src/Api/IssueTrait.php
@@ -13,7 +13,8 @@ trait IssueTrait
      * @return string
      *   The label if known, or the casted string value if not.
      */
-    public function getIssueCategoryLabel(int $value): string {
+    public function getIssueCategoryLabel(int $value): string
+    {
         switch ($value) {
             case 1:
                 return 'Bug report';
@@ -39,7 +40,8 @@ trait IssueTrait
      * @return string
      *   The label if known, or the casted string value if not.
      */
-    public function getIssuePriorityLabel(int $value): string {
+    public function getIssuePriorityLabel(int $value): string
+    {
         switch ($value) {
             case 100:
                 return 'Minor';
@@ -63,7 +65,8 @@ trait IssueTrait
      * @return string
      *   The label if known, or the casted string value if not.
      */
-    public function getIssueStatusLabel(int $value): string {
+    public function getIssueStatusLabel(int $value): string
+    {
         switch ($value) {
             case 1:
                 return 'Active';

--- a/src/Api/RawResponse.php
+++ b/src/Api/RawResponse.php
@@ -31,7 +31,8 @@ class RawResponse
      * @return mixed
      *   The JSON parsed body in the response.
      */
-    public function getContent() {
+    public function getContent()
+    {
         return $this->response;
     }
 }

--- a/src/Api/RawResponse.php
+++ b/src/Api/RawResponse.php
@@ -24,4 +24,14 @@ class RawResponse
         }
         return null;
     }
+
+    /**
+     * Get the full response body.
+     *
+     * @return mixed
+     *   The JSON parsed body in the response.
+     */
+    public function getContent() {
+        return $this->response;
+    }
 }

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -47,6 +47,7 @@ class Application extends ParentApplication
         $commands[] = new Command\Issue\Patch();
         $commands[] = new Command\Issue\Interdiff();
         $commands[] = new Command\Issue\Apply();
+        $commands[] = new Command\Issue\Show();
         $commands[] = new Command\Project\Link();
         $commands[] = new Command\Project\Kanban();
         $commands[] = new Command\Project\ProjectIssues();

--- a/src/Cli/Command/Issue/Show.php
+++ b/src/Cli/Command/Issue/Show.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace mglaman\DrupalOrgCli\Command\Issue;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use mglaman\DrupalOrg\IssueTrait;
+
+class Show extends IssueCommandBase
+{
+    use IssueTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setName('issue:show')
+            ->addArgument('nid', InputArgument::REQUIRED, 'The issue node ID')
+            ->addOption(
+                'format',
+                'f',
+                InputOption::VALUE_OPTIONAL,
+                'Output options: text, json. Defaults to text.',
+                'text'
+            )
+            ->setDescription('Show a given issue information.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $nid = $this->stdIn->getArgument('nid');
+        $issue = $this->client->getNode($nid);
+        $issue_data = $issue->getContent();
+        $format = $this->stdIn->getOption('format');
+
+        if ($format == 'json') {
+            $this->stdOut->writeln(json_encode($issue_data));
+            return 0;
+        }
+        // format option is text.
+        $this->stdOut->writeln(sprintf('Title: %s', $issue->get('title')));
+        $this->stdOut->writeln(sprintf('Status: %s', $this->getIssueStatusLabel($issue->get('field_issue_status'))));
+        $this->stdOut->writeln(sprintf('Project: %s', $issue_data->field_project->machine_name));
+        $this->stdOut->writeln(sprintf('Version: %s', $issue->get('field_issue_version')));
+        $this->stdOut->writeln(sprintf('Component: %s', $issue->get('field_issue_component')));
+        $this->stdOut->writeln(sprintf('Priority: %s', $this->getIssuePriorityLabel($issue->get('field_issue_priority'))));
+        $this->stdOut->writeln(sprintf('Category: %s', $this->getIssueCategoryLabel($issue->get('field_issue_category'))));
+        // Assigned field does not seem to be exposed on API.
+        // TODO Convert to username.
+        $this->stdOut->writeln(sprintf('Reporter: %s', $issue_data->author->id));
+        $this->stdOut->writeln(sprintf('Created: %s', date('r', $issue->get('created'))));
+        $this->stdOut->writeln(sprintf('Updated: %s', date('r', $issue->get('changed'))));
+        $this->stdOut->writeln(sprintf("\nIssue summary:\n%s", strip_tags($issue_data->body->value)));
+        return 0;
+    }
+}

--- a/tests/src/RawResponseTest.php
+++ b/tests/src/RawResponseTest.php
@@ -5,9 +5,11 @@ namespace mglaman\DrupalOrg\Tests;
 use mglaman\DrupalOrg\RawResponse;
 use PHPUnit\Framework\TestCase;
 
-class RawResponseTest extends TestCase {
+class RawResponseTest extends TestCase
+{
 
-    public function testGet(): void {
+    public function testGet(): void
+    {
         $sut = new RawResponse('{"message": "foobar"}');
         self::assertEquals('foobar', $sut->get('message'));
         self::assertEquals(null, $sut->get('baz'));


### PR DESCRIPTION
It would be handy to have a command that show the minimal issue information.

Also, it would be great to have the full JSON reply from responses on an internal public API, that later on a case like this can be used to output the JSON body response.
That together with a pipe to a tool like `jq` can be really useful!

@mglaman, let me know if this sounds OK, I am mainly porting this from an old script I wrote in shell to interact with d.o API :sweat_smile: 