### PR TITLE
building phar requires PHP 8.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "8.1"
+          php-version: "8.2"
 
       - name: "Install dependencies"
         run: "composer install --no-interaction --no-progress --no-suggest --no-dev"


### PR DESCRIPTION
fixed the CI with https://github.com/mglaman/drupalorg-cli/pull/239 but not the release release workflow
