### PR TITLE
Fix deprecated set-output workflow command in GitHub Actions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Get Composer Cache Directory
       id: composer-cache
       run: |
-        echo "::set-output name=dir::$(composer config cache-files-dir)"
+        echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v5
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
@@ -56,7 +56,7 @@ jobs:
     - name: Get Composer Cache Directory
       id: composer-cache
       run: |
-        echo "::set-output name=dir::$(composer config cache-files-dir)"
+        echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v5
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
@@ -84,7 +84,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
@@ -118,7 +118,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}


### PR DESCRIPTION
## Summary

- Replaces the deprecated `::set-output` workflow command with the modern `$GITHUB_OUTPUT` environment file approach
- Updates all 4 Composer cache steps in the `phpcs`, `phpstan`, `e2e`, and `phar` jobs

Closes #255

## Test plan

- [x] Confirm GitHub Actions no longer shows the `set-output` deprecation warning
- [x] Verify Composer cache steps still function correctly (`steps.composer-cache.outputs.dir` references remain valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)