### PR TITLE
Have e2e job use the built phar artifact

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -68,40 +68,6 @@ jobs:
     - name: phpstan
       run: ./vendor/bin/phpstan analyse src
 
-  e2e:
-    runs-on: ubuntu-latest
-    needs:
-      - validate
-      - phpstan
-    steps:
-      - uses: actions/checkout@v6
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          coverage: "none"
-          php-version: "8.1"
-          tools: composer:v2
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
-      - name: project:issues
-        run: php drupalorg project:issues address
-      - name: project:kanban
-        run: php drupalorg project:kanban address
-      - name: project:link
-        run: php drupalorg project:link address
-      - name: project:releases
-        run: php drupalorg project:releases address
-
   phar:
     runs-on: ubuntu-latest
     needs:
@@ -132,3 +98,36 @@ jobs:
           composer run box-install
           composer run box-build
           composer run box-info
+      - name: Upload phar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: drupalorg-phar
+          path: drupalorg.phar
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - validate
+      - phpstan
+      - phar
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.2", "8.3", "8.4"]
+    steps:
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+      - name: Download phar artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: drupalorg-phar
+      - name: project:issues
+        run: php drupalorg.phar project:issues address
+      - name: project:kanban
+        run: php drupalorg.phar project:kanban address
+      - name: project:link
+        run: php drupalorg.phar project:link address
+      - name: project:releases
+        run: php drupalorg.phar project:releases address


### PR DESCRIPTION
## Summary

- Uploads `drupalorg.phar` as a GitHub Actions artifact from the `phar` job
- Rewrites the `e2e` job to download the artifact and test it via `php drupalorg.phar` instead of the dev source tree
- Adds a PHP version matrix (`8.1`, `8.2`, `8.3`, `8.4`) to confirm minimum version support across all supported PHP versions
- Removes the unnecessary composer install from `e2e` since the phar is self-contained

## Test plan

- [x] `phar` job completes and uploads a `drupalorg-phar` artifact visible in the Actions run summary
- [x] `e2e` job matrix (4 PHP versions) downloads the phar and runs all 4 commands successfully
- [x] Confirm the artifact is downloadable from the Actions run summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)