### PR TITLE
Add PHPUnit job to GitHub Actions workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -68,11 +68,37 @@ jobs:
     - name: phpstan
       run: ./vendor/bin/phpstan analyse src
 
+  phpunit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: "Install PHP"
+      uses: "shivammathur/setup-php@v2"
+      with:
+        coverage: "none"
+        php-version: "8.1"
+        tools: composer:v2
+    - name: Get Composer Cache Directory
+      id: composer-cache
+      run: |
+        echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+    - uses: actions/cache@v5
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress --no-suggest
+    - name: phpunit
+      run: ./vendor/bin/phpunit
+
   phar:
     runs-on: ubuntu-latest
     needs:
       - validate
       - phpstan
+      - phpunit
     steps:
       - uses: actions/checkout@v6
       - name: "Install PHP"


### PR DESCRIPTION
## Summary

- Adds a `phpunit` job to the CI workflow that runs `./vendor/bin/phpunit`
- Gates the `phar` build job on `phpunit` passing (alongside existing `validate` and `phpstan` gates)

## Test plan

- [x] Confirm the `phpunit` job appears in the Actions workflow graph and passes
- [x] Confirm the `phar` job lists `phpunit` as a dependency in the workflow graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)