### PR TITLE
Add ActionInterface and ResultInterface foundation

### DIFF
--- a/src/Api/Action/ActionInterface.php
+++ b/src/Api/Action/ActionInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace mglaman\DrupalOrg\Action;
+
+/**
+ * Contract for Action classes.
+ *
+ * Actions encapsulate discrete units of business logic for interacting with
+ * the Drupal.org API. They are channel-agnostic: the same Action can be
+ * invoked by a Symfony Console command, an MCP server, or any other consumer.
+ *
+ * Implementations must define __invoke() with domain-specific parameters
+ * returning a concrete ResultInterface implementation.
+ */
+interface ActionInterface
+{
+}

--- a/src/Api/Result/ResultInterface.php
+++ b/src/Api/Result/ResultInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace mglaman\DrupalOrg\Result;
+
+/**
+ * Contract for Result DTOs.
+ *
+ * Results are structured value objects returned by Action classes. They
+ * implement \JsonSerializable so they can be serialized for JSON output
+ * (e.g. --format=json) or consumed by non-CLI channels such as an MCP server.
+ */
+interface ResultInterface extends \JsonSerializable
+{
+}


### PR DESCRIPTION
## Summary

- Adds `mglaman\DrupalOrg\Action\ActionInterface` — contract for channel-agnostic business logic units
- Adds `mglaman\DrupalOrg\Result\ResultInterface` — contract for `JsonSerializable` result DTOs
- No existing code modified; foundation for sub-tasks #277–#280 (part of #270)

Closes #276.

## Test plan

- [x] `vendor/bin/phpstan analyse src` — level 6 clean
- [x] `vendor/bin/phpunit` — all 20 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)