### PR TITLE
Refactor issue:show using GetIssueAction (#277)

### DIFF
--- a/src/Api/Action/Issue/GetIssueAction.php
+++ b/src/Api/Action/Issue/GetIssueAction.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace mglaman\DrupalOrg\Action\Issue;
+
+use mglaman\DrupalOrg\Action\ActionInterface;
+use mglaman\DrupalOrg\Client;
+use mglaman\DrupalOrg\Result\Issue\IssueResult;
+
+class GetIssueAction implements ActionInterface
+{
+    public function __construct(private readonly Client $client)
+    {
+    }
+
+    public function __invoke(string $nid): IssueResult
+    {
+        $issue = $this->client->getNode($nid);
+        return IssueResult::fromIssueNode($issue);
+    }
+}

--- a/src/Api/Result/Issue/IssueResult.php
+++ b/src/Api/Result/Issue/IssueResult.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace mglaman\DrupalOrg\Result\Issue;
+
+use mglaman\DrupalOrg\Entity\IssueNode;
+use mglaman\DrupalOrg\Result\ResultInterface;
+
+class IssueResult implements ResultInterface
+{
+    public function __construct(
+        public readonly string $nid,
+        public readonly string $title,
+        public readonly int $created,
+        public readonly int $changed,
+        public readonly int $fieldIssueStatus,
+        public readonly int $fieldIssueCategory,
+        public readonly int $fieldIssuePriority,
+        public readonly string $fieldIssueVersion,
+        public readonly string $fieldIssueComponent,
+        public readonly string $fieldProjectMachineName,
+        public readonly ?string $authorId,
+        public readonly ?string $bodyValue,
+    ) {
+    }
+
+    public static function fromIssueNode(IssueNode $issue): self
+    {
+        return new self(
+            nid: $issue->nid,
+            title: $issue->title,
+            created: $issue->created,
+            changed: $issue->changed,
+            fieldIssueStatus: $issue->fieldIssueStatus,
+            fieldIssueCategory: $issue->fieldIssueCategory,
+            fieldIssuePriority: $issue->fieldIssuePriority,
+            fieldIssueVersion: $issue->fieldIssueVersion,
+            fieldIssueComponent: $issue->fieldIssueComponent,
+            fieldProjectMachineName: $issue->fieldProjectMachineName,
+            authorId: $issue->authorId,
+            bodyValue: $issue->bodyValue,
+        );
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'nid' => $this->nid,
+            'title' => $this->title,
+            'created' => $this->created,
+            'changed' => $this->changed,
+            'field_issue_status' => $this->fieldIssueStatus,
+            'field_issue_category' => $this->fieldIssueCategory,
+            'field_issue_priority' => $this->fieldIssuePriority,
+            'field_issue_version' => $this->fieldIssueVersion,
+            'field_issue_component' => $this->fieldIssueComponent,
+            'field_project_machine_name' => $this->fieldProjectMachineName,
+            'author_id' => $this->authorId,
+            'body_value' => $this->bodyValue,
+        ];
+    }
+}

--- a/src/Cli/Command/Issue/Show.php
+++ b/src/Cli/Command/Issue/Show.php
@@ -2,19 +2,18 @@
 
 namespace mglaman\DrupalOrgCli\Command\Issue;
 
+use mglaman\DrupalOrg\Action\Issue\GetIssueAction;
+use mglaman\DrupalOrg\IssueTrait;
+use mglaman\DrupalOrgCli\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use mglaman\DrupalOrg\IssueTrait;
 
-class Show extends IssueCommandBase
+class Show extends Command
 {
     use IssueTrait;
 
-    /**
-     * {@inheritdoc}
-     */
     protected function configure(): void
     {
         $this
@@ -30,33 +29,27 @@ class Show extends IssueCommandBase
             ->setDescription('Show a given issue information.');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $nid = $this->stdIn->getArgument('nid');
-        $issue = $this->client->getNode($nid);
+        $result = (new GetIssueAction($this->client))($nid);
         $format = $this->stdIn->getOption('format');
 
         if ($format == 'json') {
-            $this->stdOut->writeln(json_encode($issue));
+            $this->stdOut->writeln(json_encode($result));
             return 0;
         }
-        // format option is text.
-        $this->stdOut->writeln(sprintf('Title: %s', $issue->title));
-        $this->stdOut->writeln(sprintf('Status: %s', $this->getIssueStatusLabel($issue->fieldIssueStatus)));
-        $this->stdOut->writeln(sprintf('Project: %s', $issue->fieldProjectMachineName));
-        $this->stdOut->writeln(sprintf('Version: %s', $issue->fieldIssueVersion));
-        $this->stdOut->writeln(sprintf('Component: %s', $issue->fieldIssueComponent));
-        $this->stdOut->writeln(sprintf('Priority: %s', $this->getIssuePriorityLabel($issue->fieldIssuePriority)));
-        $this->stdOut->writeln(sprintf('Category: %s', $this->getIssueCategoryLabel($issue->fieldIssueCategory)));
-        // Assigned field does not seem to be exposed on API.
-        // TODO Convert to username.
-        $this->stdOut->writeln(sprintf('Reporter: %s', $issue->authorId ?? ''));
-        $this->stdOut->writeln(sprintf('Created: %s', date('r', $issue->created)));
-        $this->stdOut->writeln(sprintf('Updated: %s', date('r', $issue->changed)));
-        $this->stdOut->writeln(sprintf("\nIssue summary:\n%s", strip_tags($issue->bodyValue ?? '')));
+        $this->stdOut->writeln(sprintf('Title: %s', $result->title));
+        $this->stdOut->writeln(sprintf('Status: %s', $this->getIssueStatusLabel($result->fieldIssueStatus)));
+        $this->stdOut->writeln(sprintf('Project: %s', $result->fieldProjectMachineName));
+        $this->stdOut->writeln(sprintf('Version: %s', $result->fieldIssueVersion));
+        $this->stdOut->writeln(sprintf('Component: %s', $result->fieldIssueComponent));
+        $this->stdOut->writeln(sprintf('Priority: %s', $this->getIssuePriorityLabel($result->fieldIssuePriority)));
+        $this->stdOut->writeln(sprintf('Category: %s', $this->getIssueCategoryLabel($result->fieldIssueCategory)));
+        $this->stdOut->writeln(sprintf('Reporter: %s', $result->authorId ?? ''));
+        $this->stdOut->writeln(sprintf('Created: %s', date('r', $result->created)));
+        $this->stdOut->writeln(sprintf('Updated: %s', date('r', $result->changed)));
+        $this->stdOut->writeln(sprintf("\nIssue summary:\n%s", strip_tags($result->bodyValue ?? '')));
         return 0;
     }
 }

--- a/tests/src/Action/Issue/GetIssueActionTest.php
+++ b/tests/src/Action/Issue/GetIssueActionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace mglaman\DrupalOrg\Tests\Action\Issue;
+
+use mglaman\DrupalOrg\Action\Issue\GetIssueAction;
+use mglaman\DrupalOrg\Client;
+use mglaman\DrupalOrg\Entity\IssueNode;
+use mglaman\DrupalOrg\Result\Issue\IssueResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GetIssueAction::class)]
+#[CoversClass(IssueResult::class)]
+class GetIssueActionTest extends TestCase
+{
+    private static function fixture(): \stdClass
+    {
+        return json_decode(
+            file_get_contents(__DIR__ . '/../../../fixtures/issue_node.json'),
+            false,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+    }
+
+    public function testInvoke(): void
+    {
+        $issueNode = IssueNode::fromStdClass(self::fixture());
+
+        $client = $this->createMock(Client::class);
+        $client->method('getNode')->with('3383637')->willReturn($issueNode);
+
+        $action = new GetIssueAction($client);
+        $result = $action('3383637');
+
+        self::assertInstanceOf(IssueResult::class, $result);
+        self::assertSame('3383637', $result->nid);
+        self::assertSame('Schedule transition button size is different for first transition and for second transition', $result->title);
+        self::assertSame(6, $result->fieldIssueStatus);
+        self::assertSame('drupal', $result->fieldProjectMachineName);
+        self::assertSame('11.x-dev', $result->fieldIssueVersion);
+        self::assertSame('Claro theme', $result->fieldIssueComponent);
+        self::assertSame(200, $result->fieldIssuePriority);
+        self::assertSame(1, $result->fieldIssueCategory);
+        self::assertSame('3643629', $result->authorId);
+        self::assertSame(1693195104, $result->created);
+        self::assertSame(1727653295, $result->changed);
+    }
+
+    public function testJsonSerialize(): void
+    {
+        $issueNode = IssueNode::fromStdClass(self::fixture());
+
+        $client = $this->createMock(Client::class);
+        $client->method('getNode')->willReturn($issueNode);
+
+        $action = new GetIssueAction($client);
+        $result = $action('3383637');
+
+        $json = json_encode($result);
+        self::assertIsString($json);
+        $decoded = json_decode($json, true);
+        self::assertSame('3383637', $decoded['nid']);
+        self::assertSame(6, $decoded['field_issue_status']);
+        self::assertSame('drupal', $decoded['field_project_machine_name']);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `GetIssueAction` (implements `ActionInterface`) and `IssueResult` DTO (implements `ResultInterface`) as the pilot for the Action/Result pattern from #270
- `issue:show` is now a thin wrapper: it delegates to `GetIssueAction` and renders from `IssueResult`
- Fixes a latent bug: `Show` previously extended `IssueCommandBase` and hard-exited if no git repo was present, even though `issue:show` never needs one — now extends `Command` directly
- `IssueResult` supports `--format=json` via `jsonSerialize()`

## Test plan

- [ ] `vendor/bin/phpunit` — all 22 tests pass, including new `GetIssueActionTest` (covers `__invoke` and `jsonSerialize`)
- [ ] `vendor/bin/phpstan analyse src` — level 6 clean, no errors
- [ ] `php bin/drupalorg issue:show 3383637` — text output identical to before
- [ ] `php bin/drupalorg issue:show 3383637 -f json` — valid JSON from `IssueResult`
- [ ] `php bin/drupalorg issue:show 3383637` works outside a git repository (bug fix)

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)