### PR TITLE
fix: resolve main project instead of issue fork for mr:* commands

### DIFF
--- a/src/Api/Action/MergeRequest/AbstractMergeRequestAction.php
+++ b/src/Api/Action/MergeRequest/AbstractMergeRequestAction.php
@@ -20,8 +20,7 @@ abstract class AbstractMergeRequestAction implements ActionInterface
     protected function resolveGitLabProject(string $nid): array
     {
         $issue = $this->client->getNode($nid);
-        $remoteName = $issue->fieldProjectMachineName . '-' . $nid;
-        $projectPath = 'issue/' . $remoteName;
+        $projectPath = 'project/' . $issue->fieldProjectMachineName;
         $project = $this->gitLabClient->getProject($projectPath);
         return [(int) $project->id, $projectPath];
     }

--- a/tests/src/Action/MergeRequest/GetMergeRequestDiffActionTest.php
+++ b/tests/src/Action/MergeRequest/GetMergeRequestDiffActionTest.php
@@ -70,6 +70,27 @@ class GetMergeRequestDiffActionTest extends TestCase
         return new GetMergeRequestDiffAction($client, $gitLabClient);
     }
 
+    public function testResolvesMainProjectNotIssueFork(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('getNode')->willReturn(self::makeIssueNode());
+
+        $gitLabClient = $this->createMock(GitLabClient::class);
+        $gitLabClient->expects($this->once())
+            ->method('getProject')
+            ->with('project/drupal')
+            ->willReturn(self::makeProject());
+        $gitLabClient->method('getMergeRequest')->willReturn(self::makeMr());
+        $gitLabClient->method('getMergeRequestDiffs')->willReturn([
+            self::makeFileDiff("--- a/foo.php\n+++ b/foo.php\n@@ -1 +1 @@\n-old\n+new\n"),
+        ]);
+
+        $action = new GetMergeRequestDiffAction($client, $gitLabClient);
+        $result = $action('3383637', 7);
+
+        self::assertSame(7, $result->iid);
+    }
+
     public function testUnifiedDiffConcatenation(): void
     {
         $client = $this->createMock(Client::class);

--- a/tests/src/Action/MergeRequest/GetMergeRequestFilesActionTest.php
+++ b/tests/src/Action/MergeRequest/GetMergeRequestFilesActionTest.php
@@ -64,7 +64,7 @@ class GetMergeRequestFilesActionTest extends TestCase
         $client->method('getNode')->with('3383637')->willReturn(self::makeIssueNode());
 
         $gitLabClient = $this->createMock(GitLabClient::class);
-        $gitLabClient->method('getProject')->with('issue/drupal-3383637')->willReturn(self::makeProject());
+        $gitLabClient->method('getProject')->with('project/drupal')->willReturn(self::makeProject());
         $gitLabClient->method('getMergeRequestDiffs')->with(12345, 7)->willReturn([
             self::makeFileDiff('src/Foo.php'),
             self::makeFileDiff('src/Bar.php', newFile: true),

--- a/tests/src/Action/MergeRequest/ListMergeRequestsActionTest.php
+++ b/tests/src/Action/MergeRequest/ListMergeRequestsActionTest.php
@@ -70,7 +70,7 @@ class ListMergeRequestsActionTest extends TestCase
         $client->method('getNode')->with('3383637')->willReturn(self::makeIssueNode());
 
         $gitLabClient = $this->createMock(GitLabClient::class);
-        $gitLabClient->method('getProject')->with('issue/drupal-3383637')->willReturn(self::makeProject());
+        $gitLabClient->method('getProject')->with('project/drupal')->willReturn(self::makeProject());
         $gitLabClient->expects($this->once())
             ->method('getMergeRequests')
             ->with(12345, ['per_page' => 100, 'state' => 'opened'])
@@ -80,7 +80,7 @@ class ListMergeRequestsActionTest extends TestCase
         $result = $action('3383637', MergeRequestState::Opened);
 
         self::assertInstanceOf(MergeRequestListResult::class, $result);
-        self::assertSame('issue/drupal-3383637', $result->projectPath);
+        self::assertSame('project/drupal', $result->projectPath);
         self::assertCount(1, $result->mergeRequests);
         self::assertInstanceOf(MergeRequestItem::class, $result->mergeRequests[0]);
         self::assertSame(7, $result->mergeRequests[0]->iid);


### PR DESCRIPTION
## Summary

- **Fixes #310**: `mr:diff` (and all `mr:*` commands) were resolving the issue fork project (`issue/{name}-{nid}`) instead of the main project (`project/{name}`), causing 404 errors since MRs live on the main project in Drupal.org's GitLab.
- Changed `resolveGitLabProject()` in `AbstractMergeRequestAction` to use `project/` prefix, fixing all downstream commands (`mr:diff`, `mr:status`, `mr:files`, `mr:logs`, `mr:list`).
- Added test asserting the correct project path is resolved; updated existing tests.

## Test plan

- [x] `vendor/bin/phpstan analyse src` — passes
- [x] `vendor/bin/phpunit` — all 26 MR tests pass
- [x] Manual: `drupalorg mr:diff 3571536 667` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)