### PR TITLE
Rename drupal-work-on-issue SKILL folder and name

### DIFF
--- a/skills/drupalorg-work-on-issue/SKILL.md
+++ b/skills/drupalorg-work-on-issue/SKILL.md
@@ -1,22 +1,22 @@
 ---
-name: drupal-work-on-issue
+name: drupalorg-work-on-issue
 description: >
   Agentic workflow for contributing to a Drupal.org issue via GitLab MR. Orchestrates
   fork verification, directory alignment, remote setup, branch checkout, and the
   fix/push/pipeline loop.
 ---
 
-# /drupal-work-on-issue
+# /drupalorg-work-on-issue
 
 **Purpose:** Agentic workflow for contributing to a Drupal.org issue via GitLab MR.
 
-**Usage:** `/drupal-work-on-issue <nid>`
+**Usage:** `/drupalorg-work-on-issue <nid>`
 
 ---
 
 ## Instructions
 
-When the user invokes `/drupal-work-on-issue <nid>`, execute the following workflow. Pause at
+When the user invokes `/drupalorg-work-on-issue <nid>`, execute the following workflow. Pause at
 each checkpoint marked **[PAUSE]** — present findings and wait for the user to confirm
 before proceeding.
 


### PR DESCRIPTION
I know that this may be a useless or opinioned PR but I would propose to **rename** the SKILL folder and the contents of `drupal-work-on-issue` as `drupalorg-work-on-issue`. The main reasons are:

- It makes more sense to use the same prefix of `drupalorg` like ther other skills.
- The generic prefix `drupal` may cause conflicts with other tools in the feature that could provide skills.
- Same prefix helps the LLM organize better the context and memory of the skills.

On the other hand, I am not sure how this would affect existing (installed) skills on current **drupalorg** cli installations. We may need a script to rename the path here if this PR is merged.

Thanks in advanced for reading this.