### PR TITLE
docs: list skill:install in README Commands section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Available commands:
   project:link                         Opens project page
   project:release-notes (prn)          View release notes for a release
   project:releases                     Lists available releases
+ skill
+  skill:install                        Installs all drupalorg-cli agent skills into .claude/skills/ in the current directory.
 ````
 
 ## Getting Started


### PR DESCRIPTION
The `skill:install` command (added in `src/Cli/Command/Skill/Install.php`) is missing from the Commands block in `README.md`, which otherwise mirrors the output of `drupalorg list`. This PR adds the `skill` group with the `skill:install` command so the README reflects the current command surface.

Spotted while integrating drupalorg-cli into a team DDEV setup — new users following the README couldn't discover the command that installs the bundled Claude Code skills.