### PR TITLE
feat: support GitLab work items for projects without a Drupal.org issue queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Drupal.org CLI
 --------------
 [![Latest Stable Version](https://poser.pugx.org/mglaman/drupalorg-cli/v/stable)](https://packagist.org/packages/mglaman/drupalorg-cli) [![Total Downloads](https://poser.pugx.org/mglaman/drupalorg-cli/downloads)](https://packagist.org/packages/mglaman/drupalorg-cli) [![Latest Unstable Version](https://poser.pugx.org/mglaman/drupalorg-cli/v/unstable)](https://packagist.org/packages/mglaman/drupalorg-cli) [![License](https://poser.pugx.org/mglaman/drupalorg-cli/license)](https://packagist.org/packages/mglaman/drupalorg-cli)
 
-A command line tool for interfacing with Drupal.org. Uses the Drupal.org REST API.
+A command line tool for interfacing with Drupal.org and GitLab (git.drupalcode.org). Uses the Drupal.org REST API and GitLab REST API.
 
 ## Requirements
 
@@ -92,28 +92,60 @@ drupalorg list
 
 ````
 Available commands:
-  help                                 Displays help for a command
-  list                                 Lists commands
- cache
-  cache:clear (cc)                     Clears caches
+  help                      Display help for a command
+  list                      List commands
  issue
-  issue:apply                          Applies the latest patch from an issue.
-  issue:branch                         Creates a branch for the issue.
-  issue:interdiff                      Generate an interdiff for the issue from local changes.
-  issue:link                           Opens an issue
-  issue:patch                          Generate a patch for the issue from committed local changes.
+  issue:apply               Applies the latest patch from an issue.
+  issue:branch              Creates a branch for the issue.
+  issue:checkout            Check out a branch from the GitLab issue fork.
+  issue:get-fork            Show the GitLab issue fork URLs and branches.
+  issue:interdiff           Generate an interdiff for the issue from committed local changes.
+  issue:link                Opens an issue
+  issue:patch               Generate a patch for the issue from committed local changes.
+  issue:search        [is]  Searches issues for a project by title keyword.
+  issue:setup-remote        Add the GitLab issue fork as a git remote and fetch it.
+  issue:show                Show a given issue information.
  maintainer
-  maintainer:issues (mi)               Lists issues for a user, based on maintainer.
-  maintainer:release-notes (rn, mrn)   Generate release notes.
+  maintainer:issues   [mi]  Lists issues for a user, based on maintainer.
+  maintainer:release-notes  [rn|mrn] Generate release notes.
+ mcp
+  mcp:config                Output the Claude Desktop MCP configuration snippet.
+  mcp:serve                 Start a Model Context Protocol server over stdio.
+ mr
+  mr:diff                   Show the unified diff for a merge request.
+  mr:files                  List changed files in a merge request.
+  mr:list            [mrl]  List merge requests for a Drupal.org issue fork or project.
+  mr:logs                   Show failed job traces from the latest pipeline for a merge request.
+  mr:status                 Show the pipeline status for a merge request.
  project
-  project:issues (pi)                  Lists issues for a project.
-  project:kanban                       Opens project kanban
-  project:link                         Opens project page
-  project:release-notes (prn)          View release notes for a release
-  project:releases                     Lists available releases
+  project:issues      [pi]  Lists issues for a project.
+  project:kanban            Opens project kanban
+  project:link              Opens project page
+  project:release-notes [prn] View release notes for a release
+  project:releases          Lists available releases
  skill
-  skill:install                        Installs all drupalorg-cli agent skills into .claude/skills/ in the current directory.
+  skill:install             Installs all drupalorg-cli agent skills into .claude/skills/ in the current directory.
 ````
+
+## GitLab work items
+
+Some Drupal.org projects have migrated their issue queues to GitLab work items at `git.drupalcode.org`. These projects are detected automatically via `field_project_has_issue_queue` on the project node.
+
+**`project:issues`** fetches from the GitLab API instead of Drupal.org for these projects.
+
+The following commands accept a GitLab work item URL in place of a Drupal.org issue NID:
+
+```bash
+drupalorg issue:show https://git.drupalcode.org/project/ai_context/-/work_items/3586157
+drupalorg issue:get-fork https://git.drupalcode.org/project/ai_context/-/work_items/3586157
+drupalorg mr:list https://git.drupalcode.org/project/ai_context/-/work_items/3586157
+```
+
+MR URLs also work directly:
+
+```bash
+drupalorg mr:list https://git.drupalcode.org/project/ai_context/-/merge_requests/131
+```
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -133,15 +133,20 @@ Some Drupal.org projects have migrated their issue queues to GitLab work items a
 
 **`project:issues`** fetches from the GitLab API instead of Drupal.org for these projects.
 
-The following commands accept a GitLab work item URL in place of a Drupal.org issue NID:
+The following commands accept a work item reference in place of a Drupal.org issue NID:
 
 ```bash
+# Full URL
 drupalorg issue:show https://git.drupalcode.org/project/ai_context/-/work_items/3586157
-drupalorg issue:get-fork https://git.drupalcode.org/project/ai_context/-/work_items/3586157
-drupalorg mr:list https://git.drupalcode.org/project/ai_context/-/work_items/3586157
+
+# Explicit path
+drupalorg issue:show project/ai_context#3586157
+
+# Shorthand (project/ prefix assumed)
+drupalorg issue:show ai_context#3586157
 ```
 
-MR URLs also work directly:
+The same formats work for `issue:get-fork` and `mr:list`. MR URLs also work directly:
 
 ```bash
 drupalorg mr:list https://git.drupalcode.org/project/ai_context/-/merge_requests/131

--- a/skills/drupalorg-cli/SKILL.md
+++ b/skills/drupalorg-cli/SKILL.md
@@ -3,16 +3,33 @@ name: drupalorg-cli
 description: >
   CLI for Drupal.org issue lifecycle management. Use when fetching issue details,
   generating patches/interdiffs, listing project or maintainer issues, looking up
-  releases, or working with GitLab merge requests on issue forks. Pass --format=llm
-  to every read command for structured XML output optimised for agent consumption.
+  releases, or working with GitLab merge requests on issue forks. Also supports
+  projects that have migrated to GitLab work items. Pass --format=llm to every
+  read command for structured XML output optimised for agent consumption.
 ---
 
 ## Overview
 
-`drupalorg-cli` (invoked as `drupalorg`) wraps Drupal.org's REST and JSON:API
-endpoints. It covers the full contribution lifecycle: browsing issues, creating
+`drupalorg-cli` (invoked as `drupalorg`) wraps Drupal.org's REST and GitLab REST
+APIs. It covers the full contribution lifecycle: browsing issues, creating
 branches, generating patches and interdiffs, applying patches, working with GitLab
 issue forks and merge requests, and browsing releases.
+
+Some Drupal.org projects have migrated their issue queues to GitLab work items
+at `git.drupalcode.org`. These projects are detected automatically — `project:issues`
+fetches from the GitLab API instead of Drupal.org for them.
+
+### Work item references
+
+`issue:show`, `issue:get-fork`, and `mr:list` all accept a **WorkItemRef** in
+place of a plain Drupal.org NID:
+
+| Format | Example |
+|--------|---------|
+| D.o NID | `3586157` |
+| Shorthand | `ai_context#3586157` |
+| Explicit path | `project/ai_context#3586157` |
+| Full URL | `https://git.drupalcode.org/project/ai_context/-/work_items/3586157` |
 
 ```bash
 drupalorg <command> [arguments]
@@ -36,11 +53,14 @@ with clearly labelled fields, contributor lists, and change records.
 
 ### Issue commands
 
+`<nid>` accepts a D.o NID, shorthand (`ai_context#3586157`), or full GitLab work item URL.
+
 ```bash
-# Fetch full details for an issue
+# Fetch full details for an issue (D.o or GitLab work item)
 drupalorg issue:show <nid> --format=llm
 
 # Fetch issue details including all comments (skips system-generated messages)
+# Note: --with-comments only applies to D.o issues
 drupalorg issue:show <nid> --with-comments --format=llm
 
 # Show the GitLab issue fork URLs and branches
@@ -115,8 +135,10 @@ drupalorg mr:logs 'project/drupal!708'
 
 ```bash
 # List open issues for a project
+# For projects using GitLab work items, fetches from GitLab API automatically
 # type: all (default), rtbc, or review; --core defaults to 8.x; --limit defaults to 10
 # --category filters by issue type: bug, task, feature, support, plan (omit for all categories)
+# Note: type/core/category filters only apply to D.o issue queue projects
 drupalorg project:issues [project] [type] [--category=bug|task|feature|support|plan] --format=llm
 
 # Search issues for a project by title keyword
@@ -174,7 +196,8 @@ drupalorg mr:list [nid] --format=llm --no-cache
 
 | Error | Cause | Recovery |
 |-------|-------|----------|
-| `Node not found` | Invalid or private issue NID | Verify the NID on drupal.org |
+| `Node not found` | Invalid or private issue NID, or a GitLab work item NID passed to a D.o-only command | Use a WorkItemRef instead: `ai_context#3586157` |
+| `404 Project Not Found` (GitLab) | D.o issue NID used with a GitLab work item project — D.o node has no `field_project` | Pass the full work item URL or shorthand ref |
 | `No patch found on issue` | Issue has no file attachments | Check `issue:show` to confirm files exist |
 | `No branch configured` | `issue:patch` run outside a git repo or without a tracking branch | Run `issue:branch <nid>` first |
 | `Remote … does not exist` | `issue:checkout` run before `issue:setup-remote` | Run `issue:setup-remote <nid>` first |

--- a/skills/drupalorg-issue-search/SKILL.md
+++ b/skills/drupalorg-issue-search/SKILL.md
@@ -19,11 +19,22 @@ description: >
    - `--status`: issue status filter (default: `all`)
    - `--skip`: comma-separated list of channels to skip. Valid values: `api_search`, `drupalorg_scrape`, `web_search`. For example `--skip=web_search` skips the web search, `--skip=api_search,web_search` runs only the Drupal.org scrape.
 
-2. **Detect project**: If `--project` is not provided, try to infer the project machine name from the current git remote:
+2. **Detect project and issue queue type**: If `--project` is not provided, try to infer the project machine name from the current git remote:
    ```bash
    git config --get remote.origin.url
    ```
    Extract the project name from the URL (pattern: `*/project-name.git`). If detection fails, proceed without a project filter.
+
+   Once the project name is known, check whether it uses GitLab work items:
+   ```bash
+   drupalorg project:issues <project> --limit=1 --format=json
+   ```
+   If the output contains a `"gitlab_issues"` key or the command prints
+   `"Project uses GitLab work items"` to stderr, the project has migrated.
+   In that case:
+   - Skip the `api_search` and `drupalorg_scrape` channels (they search the D.o issue queue, which is empty for this project).
+   - For `web_search`, target `site:git.drupalcode.org/project/<project>/-/issues` instead.
+   - Note to the user: "This project uses GitLab work items. Search results are from GitLab."
 
 3. **Run enabled searches in parallel** (skip any channel listed in `--skip`):
 

--- a/skills/drupalorg-issue-summary-update/SKILL.md
+++ b/skills/drupalorg-issue-summary-update/SKILL.md
@@ -17,6 +17,17 @@ the latest discussion in the comments.
 
 ## Instructions
 
+### Step 0: Detect issue type
+
+If `<nid>` looks like a GitLab work item reference — a URL containing
+`git.drupalcode.org`, or a shorthand like `ai_context#3586157` — stop immediately
+and tell the user:
+
+> "GitLab work items don't use the Drupal.org issue summary format (Problem/Motivation,
+> Proposed resolution, etc.). This skill only applies to Drupal.org issues."
+
+Do not proceed further.
+
 ### Step 1: Fetch issue with comments
 
 ```bash

--- a/skills/drupalorg-work-on-issue/SKILL.md
+++ b/skills/drupalorg-work-on-issue/SKILL.md
@@ -10,7 +10,14 @@ description: >
 
 **Purpose:** Agentic workflow for contributing to a Drupal.org issue via GitLab MR.
 
-**Usage:** `/drupalorg-work-on-issue <nid>`
+**Usage:** `/drupalorg-work-on-issue <nid-or-ref>`
+
+The argument can be:
+- A Drupal.org issue NID: `3586157`
+- A shorthand work item ref: `ai_context#3586157`
+- A full GitLab work item URL: `https://git.drupalcode.org/project/ai_context/-/work_items/3586157`
+
+All three formats are accepted by `issue:show`, `issue:get-fork`, and `mr:list`.
 
 ---
 
@@ -24,7 +31,7 @@ before proceeding.
 
 ### Step 1: Fetch issue and fork details
 
-Run both commands to gather context:
+Run both commands to gather context (substitute `<nid>` with whatever ref was provided):
 
 ```bash
 drupalorg issue:show <nid> --format=llm

--- a/src/Api/Action/GitLab/GetGitLabIssueAction.php
+++ b/src/Api/Action/GitLab/GetGitLabIssueAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\DrupalOrg\Action\GitLab;
+
+use mglaman\DrupalOrg\GitLab\Entity\GitLabIssue;
+use mglaman\DrupalOrg\GitLab\WorkItemRef;
+use mglaman\DrupalOrg\Result\GitLab\GitLabIssueResult;
+use Symfony\Component\Process\Process;
+
+class GetGitLabIssueAction
+{
+    public function __invoke(WorkItemRef $ref): GitLabIssueResult
+    {
+        $process = new Process([
+            'glab', 'issue', 'view', (string) $ref->issueId,
+            '-R', $ref->projectPath,
+            '-F', 'json',
+        ]);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new \RuntimeException(
+                sprintf(
+                    'glab issue view failed for %s#%d: %s',
+                    $ref->projectPath,
+                    $ref->issueId,
+                    trim($process->getErrorOutput())
+                )
+            );
+        }
+
+        $data = json_decode($process->getOutput(), false, 512, JSON_THROW_ON_ERROR);
+        return new GitLabIssueResult(GitLabIssue::fromStdClass($data));
+    }
+}

--- a/src/Api/Action/GitLab/GetGitLabIssueAction.php
+++ b/src/Api/Action/GitLab/GetGitLabIssueAction.php
@@ -4,34 +4,20 @@ declare(strict_types=1);
 
 namespace mglaman\DrupalOrg\Action\GitLab;
 
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
 use mglaman\DrupalOrg\GitLab\Entity\GitLabIssue;
 use mglaman\DrupalOrg\GitLab\WorkItemRef;
 use mglaman\DrupalOrg\Result\GitLab\GitLabIssueResult;
-use Symfony\Component\Process\Process;
 
 class GetGitLabIssueAction
 {
+    public function __construct(private readonly GitLabClient $gitLabClient)
+    {
+    }
+
     public function __invoke(WorkItemRef $ref): GitLabIssueResult
     {
-        $process = new Process([
-            'glab', 'issue', 'view', (string) $ref->issueId,
-            '-R', $ref->projectPath,
-            '-F', 'json',
-        ]);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            throw new \RuntimeException(
-                sprintf(
-                    'glab issue view failed for %s#%d: %s',
-                    $ref->projectPath,
-                    $ref->issueId,
-                    trim($process->getErrorOutput())
-                )
-            );
-        }
-
-        $data = json_decode($process->getOutput(), false, 512, JSON_THROW_ON_ERROR);
+        $data = $this->gitLabClient->getIssue($ref->projectPath, $ref->issueId);
         return new GitLabIssueResult(GitLabIssue::fromStdClass($data));
     }
 }

--- a/src/Api/Action/GitLab/ListGitLabIssuesAction.php
+++ b/src/Api/Action/GitLab/ListGitLabIssuesAction.php
@@ -4,43 +4,29 @@ declare(strict_types=1);
 
 namespace mglaman\DrupalOrg\Action\GitLab;
 
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
 use mglaman\DrupalOrg\GitLab\Entity\GitLabIssue;
 use mglaman\DrupalOrg\Result\GitLab\GitLabIssuesResult;
-use Symfony\Component\Process\Process;
 
 class ListGitLabIssuesAction
 {
+    public function __construct(private readonly GitLabClient $gitLabClient)
+    {
+    }
+
     public function __invoke(string $projectMachineName, string $state = 'opened', int $limit = 25): GitLabIssuesResult
     {
-        $cmd = [
-            'glab', 'issue', 'list',
-            '-R', 'project/' . $projectMachineName,
-            '-O', 'json',
-            '-P', (string) $limit,
+        $params = [
+            'state' => $state,
+            'per_page' => $limit,
+            'order_by' => 'created_at',
+            'sort' => 'desc',
         ];
-        if ($state === 'closed') {
-            $cmd[] = '--closed';
-        } elseif ($state === 'all') {
-            $cmd[] = '--all';
-        }
 
-        $process = new Process($cmd);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            throw new \RuntimeException(
-                sprintf(
-                    'glab issue list failed for project/%s: %s',
-                    $projectMachineName,
-                    trim($process->getErrorOutput())
-                )
-            );
-        }
-
-        $data = json_decode($process->getOutput(), false, 512, JSON_THROW_ON_ERROR);
+        $data = $this->gitLabClient->getIssues('project/' . $projectMachineName, $params);
         $issues = array_map(
             static fn(\stdClass $item) => GitLabIssue::fromStdClass($item),
-            is_array($data) ? $data : []
+            $data
         );
 
         return new GitLabIssuesResult(

--- a/src/Api/Action/GitLab/ListGitLabIssuesAction.php
+++ b/src/Api/Action/GitLab/ListGitLabIssuesAction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\DrupalOrg\Action\GitLab;
+
+use mglaman\DrupalOrg\GitLab\Entity\GitLabIssue;
+use mglaman\DrupalOrg\Result\GitLab\GitLabIssuesResult;
+use Symfony\Component\Process\Process;
+
+class ListGitLabIssuesAction
+{
+    public function __invoke(string $projectMachineName, string $state = 'opened', int $limit = 25): GitLabIssuesResult
+    {
+        $cmd = [
+            'glab', 'issue', 'list',
+            '-R', 'project/' . $projectMachineName,
+            '-O', 'json',
+            '-P', (string) $limit,
+        ];
+        if ($state === 'closed') {
+            $cmd[] = '--closed';
+        } elseif ($state === 'all') {
+            $cmd[] = '--all';
+        }
+
+        $process = new Process($cmd);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new \RuntimeException(
+                sprintf(
+                    'glab issue list failed for project/%s: %s',
+                    $projectMachineName,
+                    trim($process->getErrorOutput())
+                )
+            );
+        }
+
+        $data = json_decode($process->getOutput(), false, 512, JSON_THROW_ON_ERROR);
+        $issues = array_map(
+            static fn(\stdClass $item) => GitLabIssue::fromStdClass($item),
+            is_array($data) ? $data : []
+        );
+
+        return new GitLabIssuesResult(
+            projectMachineName: $projectMachineName,
+            issues: $issues,
+        );
+    }
+}

--- a/src/Api/Action/Issue/GetIssueForkAction.php
+++ b/src/Api/Action/Issue/GetIssueForkAction.php
@@ -15,10 +15,12 @@ class GetIssueForkAction implements ActionInterface
     ) {
     }
 
-    public function __invoke(string $nid): IssueForkResult
+    public function __invoke(string $nid, ?string $projectMachineName = null): IssueForkResult
     {
-        $issue = $this->client->getNode($nid);
-        $projectMachineName = $issue->fieldProjectMachineName;
+        if ($projectMachineName === null) {
+            $issue = $this->client->getNode($nid);
+            $projectMachineName = $issue->fieldProjectMachineName;
+        }
         $remoteName = $projectMachineName . '-' . $nid;
         $gitLabProjectPath = 'issue/' . $remoteName;
 

--- a/src/Api/Entity/Project.php
+++ b/src/Api/Entity/Project.php
@@ -8,6 +8,7 @@ class Project
         public readonly string $nid,
         public readonly string $title,
         public readonly string $machineName,
+        public readonly bool $hasIssueQueue = true,
     ) {
     }
 
@@ -17,6 +18,7 @@ class Project
             nid: (string) ($data->nid ?? ''),
             title: (string) ($data->title ?? ''),
             machineName: (string) ($data->field_project_machine_name ?? ''),
+            hasIssueQueue: (bool) ($data->field_project_has_issue_queue ?? true),
         );
     }
 }

--- a/src/Api/GitLab/Client.php
+++ b/src/Api/GitLab/Client.php
@@ -140,6 +140,31 @@ class Client
     }
 
     /**
+     * GET /projects/{path}/issues/{iid}
+     *
+     * @throws \Exception
+     */
+    public function getIssue(string $projectPath, int $iid): \stdClass
+    {
+        /** @var \stdClass $result */
+        $result = $this->get('projects/' . urlencode($projectPath) . '/issues/' . $iid);
+        return $result;
+    }
+
+    /**
+     * GET /projects/{path}/issues
+     *
+     * @param array<string, mixed> $params
+     * @return \stdClass[]
+     * @throws \Exception
+     */
+    public function getIssues(string $projectPath, array $params = []): array
+    {
+        $result = $this->get('projects/' . urlencode($projectPath) . '/issues', $params);
+        return is_array($result) ? $result : [];
+    }
+
+    /**
      * GET /projects/{id}/jobs/{job_id}/trace
      *
      * @throws \Exception

--- a/src/Api/GitLab/Entity/GitLabIssue.php
+++ b/src/Api/GitLab/Entity/GitLabIssue.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\DrupalOrg\GitLab\Entity;
+
+class GitLabIssue
+{
+    /**
+     * @param string[] $labels
+     * @param string[] $assignees
+     */
+    public function __construct(
+        public int $iid,
+        public string $title,
+        public string $description,
+        public string $state,
+        public array $labels,
+        public string $createdAt,
+        public string $updatedAt,
+        public string $webUrl,
+        public string $author,
+        public array $assignees,
+    ) {
+    }
+
+    public static function fromStdClass(\stdClass $data): self
+    {
+        $assignees = array_map(
+            static fn(\stdClass $a) => (string) ($a->username ?? $a->name ?? ''),
+            (array) ($data->assignees ?? [])
+        );
+
+        return new self(
+            iid: (int) $data->iid,
+            title: (string) ($data->title ?? ''),
+            description: (string) ($data->description ?? ''),
+            state: (string) ($data->state ?? ''),
+            labels: (array) ($data->labels ?? []),
+            createdAt: (string) ($data->created_at ?? ''),
+            updatedAt: (string) ($data->updated_at ?? ''),
+            webUrl: (string) ($data->web_url ?? ''),
+            author: (string) ($data->author->username ?? $data->author->name ?? ''),
+            assignees: $assignees,
+        );
+    }
+}

--- a/src/Api/GitLab/WorkItemRef.php
+++ b/src/Api/GitLab/WorkItemRef.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\DrupalOrg\GitLab;
+
+/**
+ * Parses a GitLab work item or issue URL into project path + issue ID.
+ *
+ * Supports:
+ *   https://git.drupalcode.org/{path}/-/work_items/{id}
+ *   https://git.drupalcode.org/{path}/-/issues/{id}
+ *
+ * On drupalcode.org the issue iid equals the Drupal.org NID.
+ */
+class WorkItemRef
+{
+    public function __construct(
+        public string $projectPath,
+        public int $issueId,
+    ) {
+    }
+
+    public static function tryParse(string $input): ?self
+    {
+        if (!str_starts_with($input, 'https://git.drupalcode.org/')) {
+            return null;
+        }
+        $pattern = '#^https://git\.drupalcode\.org/(.+)/-/(?:work_items|issues)/(\d+)#';
+        if (!preg_match($pattern, $input, $matches)) {
+            return null;
+        }
+        return new self(
+            projectPath: $matches[1],
+            issueId: (int) $matches[2],
+        );
+    }
+}

--- a/src/Api/GitLab/WorkItemRef.php
+++ b/src/Api/GitLab/WorkItemRef.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace mglaman\DrupalOrg\GitLab;
 
 /**
- * Parses a GitLab work item or issue URL into project path + issue ID.
+ * A reference to a GitLab work item / issue.
  *
  * Supports:
  *   https://git.drupalcode.org/{path}/-/work_items/{id}
  *   https://git.drupalcode.org/{path}/-/issues/{id}
+ *   project/ai_context#3586157
+ *   ai_context#3586157   (shorthand; "project/" prefix assumed)
  *
  * On drupalcode.org the issue iid equals the Drupal.org NID.
  */
@@ -23,16 +25,31 @@ class WorkItemRef
 
     public static function tryParse(string $input): ?self
     {
-        if (!str_starts_with($input, 'https://git.drupalcode.org/')) {
+        $input = trim($input);
+
+        if ($input === '' || ctype_digit($input)) {
             return null;
         }
-        $pattern = '#^https://git\.drupalcode\.org/(.+)/-/(?:work_items|issues)/(\d+)#';
-        if (!preg_match($pattern, $input, $matches)) {
+
+        // Full GitLab URL.
+        if (str_starts_with($input, 'https://git.drupalcode.org/')) {
+            $pattern = '#^https://git\.drupalcode\.org/(.+)/-/(?:work_items|issues)/(\d+)#';
+            if (preg_match($pattern, $input, $matches)) {
+                return new self(projectPath: $matches[1], issueId: (int) $matches[2]);
+            }
             return null;
         }
-        return new self(
-            projectPath: $matches[1],
-            issueId: (int) $matches[2],
-        );
+
+        // project/name#123
+        if (preg_match('~^([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+)#(\d+)$~', $input, $matches)) {
+            return new self(projectPath: $matches[1], issueId: (int) $matches[2]);
+        }
+
+        // name#123  (shorthand; "project/" assumed)
+        if (preg_match('~^([a-zA-Z0-9_-]+)#(\d+)$~', $input, $matches)) {
+            return new self(projectPath: 'project/' . $matches[1], issueId: (int) $matches[2]);
+        }
+
+        return null;
     }
 }

--- a/src/Api/Mcp/ToolRegistry.php
+++ b/src/Api/Mcp/ToolRegistry.php
@@ -5,6 +5,8 @@ namespace mglaman\DrupalOrg\Mcp;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Capability\Attribute\Schema;
 use Mcp\Schema\ToolAnnotations;
+use mglaman\DrupalOrg\Action\GitLab\GetGitLabIssueAction;
+use mglaman\DrupalOrg\Action\GitLab\ListGitLabIssuesAction;
 use mglaman\DrupalOrg\Action\Issue\GetIssueAction;
 use mglaman\DrupalOrg\Action\Issue\GetIssueBranchNameAction;
 use mglaman\DrupalOrg\Action\Issue\GetIssueForkAction;
@@ -26,6 +28,7 @@ use mglaman\DrupalOrg\Enum\MergeRequestState;
 use mglaman\DrupalOrg\Enum\ProjectIssueCategory;
 use mglaman\DrupalOrg\Enum\ProjectIssueType;
 use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
+use mglaman\DrupalOrg\GitLab\WorkItemRef;
 
 class ToolRegistry
 {
@@ -198,5 +201,29 @@ class ToolRegistry
         int $mrIid
     ): mixed {
         return (new GetMergeRequestLogsAction($this->client, new GitLabClient()))($nid, $mrIid)->jsonSerialize();
+    }
+
+    #[McpTool(annotations: new ToolAnnotations(readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true), name: 'gitlab_issue_show', description: 'Get details of a GitLab work item by URL. Use for projects that have migrated their issue queue to GitLab.')]
+    public function gitlabIssueShow(
+        #[Schema(description: 'The GitLab work item or issue URL (e.g. https://git.drupalcode.org/project/ai_context/-/work_items/3586157).')]
+        string $workItemUrl
+    ): mixed {
+        $ref = WorkItemRef::tryParse($workItemUrl);
+        if ($ref === null) {
+            throw new \InvalidArgumentException("Invalid GitLab work item URL: $workItemUrl");
+        }
+        return (new GetGitLabIssueAction())($ref)->jsonSerialize();
+    }
+
+    #[McpTool(annotations: new ToolAnnotations(readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true), name: 'gitlab_project_issues', description: 'List GitLab issues for a project that has migrated its issue queue to GitLab.')]
+    public function gitlabProjectIssues(
+        #[Schema(description: "The project machine name (e.g. 'ai_context', 'mcp_server').")]
+        string $machineName,
+        #[Schema(description: 'Issue state filter.', enum: ['opened', 'closed', 'all'])]
+        string $state = 'opened',
+        #[Schema(description: 'Maximum number of issues to return.', minimum: 1, maximum: 100)]
+        int $limit = 25
+    ): mixed {
+        return (new ListGitLabIssuesAction())($machineName, $state, $limit)->jsonSerialize();
     }
 }

--- a/src/Api/Mcp/ToolRegistry.php
+++ b/src/Api/Mcp/ToolRegistry.php
@@ -212,7 +212,7 @@ class ToolRegistry
         if ($ref === null) {
             throw new \InvalidArgumentException("Invalid GitLab work item URL: $workItemUrl");
         }
-        return (new GetGitLabIssueAction())($ref)->jsonSerialize();
+        return (new GetGitLabIssueAction(new GitLabClient()))($ref)->jsonSerialize();
     }
 
     #[McpTool(annotations: new ToolAnnotations(readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true), name: 'gitlab_project_issues', description: 'List GitLab issues for a project that has migrated its issue queue to GitLab.')]
@@ -224,6 +224,6 @@ class ToolRegistry
         #[Schema(description: 'Maximum number of issues to return.', minimum: 1, maximum: 100)]
         int $limit = 25
     ): mixed {
-        return (new ListGitLabIssuesAction())($machineName, $state, $limit)->jsonSerialize();
+        return (new ListGitLabIssuesAction(new GitLabClient()))($machineName, $state, $limit)->jsonSerialize();
     }
 }

--- a/src/Api/Result/GitLab/GitLabIssueResult.php
+++ b/src/Api/Result/GitLab/GitLabIssueResult.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\DrupalOrg\Result\GitLab;
+
+use mglaman\DrupalOrg\GitLab\Entity\GitLabIssue;
+use mglaman\DrupalOrg\Result\ResultInterface;
+
+class GitLabIssueResult implements ResultInterface
+{
+    public function __construct(
+        public readonly GitLabIssue $issue,
+    ) {
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'iid' => $this->issue->iid,
+            'title' => $this->issue->title,
+            'description' => $this->issue->description,
+            'state' => $this->issue->state,
+            'labels' => $this->issue->labels,
+            'created_at' => $this->issue->createdAt,
+            'updated_at' => $this->issue->updatedAt,
+            'web_url' => $this->issue->webUrl,
+            'author' => $this->issue->author,
+            'assignees' => $this->issue->assignees,
+        ];
+    }
+}

--- a/src/Api/Result/GitLab/GitLabIssuesResult.php
+++ b/src/Api/Result/GitLab/GitLabIssuesResult.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\DrupalOrg\Result\GitLab;
+
+use mglaman\DrupalOrg\GitLab\Entity\GitLabIssue;
+use mglaman\DrupalOrg\Result\ResultInterface;
+
+class GitLabIssuesResult implements ResultInterface
+{
+    /**
+     * @param GitLabIssue[] $issues
+     */
+    public function __construct(
+        public readonly string $projectMachineName,
+        public readonly array $issues,
+    ) {
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'project' => $this->projectMachineName,
+            'issues' => array_map(
+                static fn(GitLabIssue $issue) => [
+                    'iid' => $issue->iid,
+                    'title' => $issue->title,
+                    'state' => $issue->state,
+                    'labels' => $issue->labels,
+                    'web_url' => $issue->webUrl,
+                ],
+                $this->issues
+            ),
+        ];
+    }
+}

--- a/src/Cli/Command/Issue/GetFork.php
+++ b/src/Cli/Command/Issue/GetFork.php
@@ -31,7 +31,10 @@ class GetFork extends IssueCommandBase
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $action = new GetIssueForkAction($this->client, new GitLabClient());
-        $result = $action($this->nid);
+        $machineName = $this->workItemRef !== null
+            ? substr($this->workItemRef->projectPath, strlen('project/'))
+            : null;
+        $result = $action($this->nid, $machineName);
         $format = (string) $this->stdIn->getOption('format');
 
         if ($this->writeFormatted($result, $format)) {

--- a/src/Cli/Command/Issue/IssueCommandBase.php
+++ b/src/Cli/Command/Issue/IssueCommandBase.php
@@ -4,6 +4,7 @@ namespace mglaman\DrupalOrgCli\Command\Issue;
 
 use CzProject\GitPhp\Git;
 use CzProject\GitPhp\GitRepository;
+use mglaman\DrupalOrg\GitLab\WorkItemRef;
 use mglaman\DrupalOrgCli\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -28,6 +29,8 @@ abstract class IssueCommandBase extends Command
      */
     protected string $nid;
 
+    protected ?WorkItemRef $workItemRef = null;
+
     /**
      * Whether this command requires a git repository.
      * When false, initRepo() is skipped if nid is provided as an argument.
@@ -40,7 +43,15 @@ abstract class IssueCommandBase extends Command
     ): void {
         parent::initialize($input, $output);
 
-        $this->nid = (string) $this->stdIn->getArgument('nid');
+        $nidArg = (string) $this->stdIn->getArgument('nid');
+        $ref = $nidArg !== '' ? WorkItemRef::tryParse($nidArg) : null;
+        if ($ref !== null) {
+            $this->workItemRef = $ref;
+            $this->nid = (string) $ref->issueId;
+            return;
+        }
+
+        $this->nid = $nidArg;
         if ($this->nid === '') {
             $this->debug(
                 "Argument nid not provided. Trying to get it from current branch name."

--- a/src/Cli/Command/Issue/Show.php
+++ b/src/Cli/Command/Issue/Show.php
@@ -4,6 +4,7 @@ namespace mglaman\DrupalOrgCli\Command\Issue;
 
 use mglaman\DrupalOrg\Action\GitLab\GetGitLabIssueAction;
 use mglaman\DrupalOrg\Action\Issue\GetIssueAction;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
 use mglaman\DrupalOrg\GitLab\WorkItemRef;
 use mglaman\DrupalOrg\IssueTrait;
 use mglaman\DrupalOrgCli\Command\Command;
@@ -39,7 +40,7 @@ class Show extends Command
 
         $ref = WorkItemRef::tryParse((string) $nid);
         if ($ref !== null) {
-            $result = (new GetGitLabIssueAction())($ref);
+            $result = (new GetGitLabIssueAction(new GitLabClient()))($ref);
             if ($this->writeFormatted($result, (string) $format)) {
                 return 0;
             }

--- a/src/Cli/Command/Issue/Show.php
+++ b/src/Cli/Command/Issue/Show.php
@@ -2,7 +2,9 @@
 
 namespace mglaman\DrupalOrgCli\Command\Issue;
 
+use mglaman\DrupalOrg\Action\GitLab\GetGitLabIssueAction;
 use mglaman\DrupalOrg\Action\Issue\GetIssueAction;
+use mglaman\DrupalOrg\GitLab\WorkItemRef;
 use mglaman\DrupalOrg\IssueTrait;
 use mglaman\DrupalOrgCli\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -18,7 +20,7 @@ class Show extends Command
     {
         $this
             ->setName('issue:show')
-            ->addArgument('nid', InputArgument::REQUIRED, 'The issue node ID')
+            ->addArgument('nid', InputArgument::REQUIRED, 'The issue node ID or a GitLab work item URL')
             ->addOption(
                 'format',
                 'f',
@@ -33,9 +35,33 @@ class Show extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $nid = $this->stdIn->getArgument('nid');
+        $format = $this->stdIn->getOption('format');
+
+        $ref = WorkItemRef::tryParse((string) $nid);
+        if ($ref !== null) {
+            $result = (new GetGitLabIssueAction())($ref);
+            if ($this->writeFormatted($result, (string) $format)) {
+                return 0;
+            }
+            $issue = $result->issue;
+            $this->stdOut->writeln(sprintf('Title: %s', $issue->title));
+            $this->stdOut->writeln(sprintf('State: %s', $issue->state));
+            $this->stdOut->writeln(sprintf('Author: %s', $issue->author));
+            if ($issue->assignees !== []) {
+                $this->stdOut->writeln(sprintf('Assignees: %s', implode(', ', $issue->assignees)));
+            }
+            if ($issue->labels !== []) {
+                $this->stdOut->writeln(sprintf('Labels: %s', implode(', ', $issue->labels)));
+            }
+            $this->stdOut->writeln(sprintf('Created: %s', $issue->createdAt));
+            $this->stdOut->writeln(sprintf('Updated: %s', $issue->updatedAt));
+            $this->stdOut->writeln(sprintf('URL: %s', $issue->webUrl));
+            $this->stdOut->writeln(sprintf("\nDescription:\n%s", $issue->description));
+            return 0;
+        }
+
         $withComments = (bool) $this->stdIn->getOption('with-comments');
         $result = (new GetIssueAction($this->client))($nid, $withComments);
-        $format = $this->stdIn->getOption('format');
 
         if ($this->writeFormatted($result, (string) $format)) {
             return 0;

--- a/src/Cli/Command/MergeRequest/MrCommandBase.php
+++ b/src/Cli/Command/MergeRequest/MrCommandBase.php
@@ -54,6 +54,12 @@ abstract class MrCommandBase extends IssueCommandBase
 
         parent::initialize($input, $output);
 
+        // WorkItemRef parsed by IssueCommandBase — synthesize MergeRequestRef so
+        // MR actions use resolveFromRef() instead of resolveGitLabProject().
+        if ($this->workItemRef !== null && $this->mrRef === null) {
+            $this->mrRef = new MergeRequestRef($this->workItemRef->projectPath);
+        }
+
         $mrIid = $this->stdIn->getArgument('mr-iid');
         if ($mrIid !== null && $mrIid !== '') {
             $this->mrIid = (int) $mrIid;

--- a/src/Cli/Command/Project/ProjectIssues.php
+++ b/src/Cli/Command/Project/ProjectIssues.php
@@ -4,6 +4,7 @@ namespace mglaman\DrupalOrgCli\Command\Project;
 
 use mglaman\DrupalOrg\Action\GitLab\ListGitLabIssuesAction;
 use mglaman\DrupalOrg\Action\Project\GetProjectIssuesAction;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
 use mglaman\DrupalOrg\Enum\ProjectIssueCategory;
 use mglaman\DrupalOrg\Enum\ProjectIssueType;
 use Symfony\Component\Console\Helper\Table;
@@ -72,7 +73,7 @@ class ProjectIssues extends ProjectCommandBase
 
         if (!$this->projectData->hasIssueQueue) {
             $this->stdErr->writeln('<comment>Project uses GitLab work items (no Drupal.org issue queue).</comment>');
-            $result = (new ListGitLabIssuesAction())($this->projectData->machineName, limit: $limit);
+            $result = (new ListGitLabIssuesAction(new GitLabClient()))($this->projectData->machineName, limit: $limit);
             if ($this->writeFormatted($result, $format)) {
                 return 0;
             }

--- a/src/Cli/Command/Project/ProjectIssues.php
+++ b/src/Cli/Command/Project/ProjectIssues.php
@@ -2,6 +2,7 @@
 
 namespace mglaman\DrupalOrgCli\Command\Project;
 
+use mglaman\DrupalOrg\Action\GitLab\ListGitLabIssuesAction;
 use mglaman\DrupalOrg\Action\Project\GetProjectIssuesAction;
 use mglaman\DrupalOrg\Enum\ProjectIssueCategory;
 use mglaman\DrupalOrg\Enum\ProjectIssueType;
@@ -66,6 +67,35 @@ class ProjectIssues extends ProjectCommandBase
         InputInterface $input,
         OutputInterface $output
     ): int {
+        $format = (string) $this->stdIn->getOption('format');
+        $limit = (int) $this->stdIn->getOption('limit');
+
+        if (!$this->projectData->hasIssueQueue) {
+            $this->stdErr->writeln('<comment>Project uses GitLab work items (no Drupal.org issue queue).</comment>');
+            $result = (new ListGitLabIssuesAction())($this->projectData->machineName, limit: $limit);
+            if ($this->writeFormatted($result, $format)) {
+                return 0;
+            }
+            $output->writeln("<info>{$result->projectMachineName}</info>");
+            $table = new Table($this->stdOut);
+            $table->setHeaders(['ID', 'State', 'Title']);
+            $issues = $result->issues;
+            $count = count($issues);
+            for ($i = 0; $i < $count; $i++) {
+                $item = $issues[$i];
+                $table->addRow([
+                    '#' . $item->iid,
+                    $item->state,
+                    $item->title . PHP_EOL . '<comment>' . $item->webUrl . '</comment>',
+                ]);
+                if ($i < $count - 1) {
+                    $table->addRow(new TableSeparator());
+                }
+            }
+            $table->render();
+            return 0;
+        }
+
         $action = new GetProjectIssuesAction($this->client);
         $categoryOption = $this->stdIn->getOption('category');
         $category = $categoryOption !== null ? ProjectIssueCategory::from((string) $categoryOption) : null;
@@ -73,11 +103,11 @@ class ProjectIssues extends ProjectCommandBase
             $this->projectData,
             ProjectIssueType::from((string) $this->stdIn->getArgument('type')),
             (string) $this->stdIn->getOption('core'),
-            (int) $this->stdIn->getOption('limit'),
+            $limit,
             $category
         );
 
-        if ($this->writeFormatted($result, (string) $this->stdIn->getOption('format'))) {
+        if ($this->writeFormatted($result, $format)) {
             return 0;
         }
 

--- a/src/Cli/Formatter/AbstractFormatter.php
+++ b/src/Cli/Formatter/AbstractFormatter.php
@@ -2,6 +2,8 @@
 
 namespace mglaman\DrupalOrgCli\Formatter;
 
+use mglaman\DrupalOrg\Result\GitLab\GitLabIssueResult;
+use mglaman\DrupalOrg\Result\GitLab\GitLabIssuesResult;
 use mglaman\DrupalOrg\Result\Issue\IssueForkResult;
 use mglaman\DrupalOrg\Result\Issue\IssueResult;
 use mglaman\DrupalOrg\Result\Maintainer\MaintainerIssuesResult;
@@ -29,6 +31,8 @@ abstract class AbstractFormatter implements FormatterInterface
             $result instanceof MergeRequestStatusResult => $this->formatMergeRequestStatus($result),
             $result instanceof MergeRequestFilesResult => $this->formatMergeRequestFiles($result),
             $result instanceof MergeRequestDiffResult => $this->formatMergeRequestDiff($result),
+            $result instanceof GitLabIssueResult => $this->formatGitLabIssue($result),
+            $result instanceof GitLabIssuesResult => $this->formatGitLabIssues($result),
             default => throw new \InvalidArgumentException(
                 sprintf('Unsupported result type: %s', get_class($result))
             ),
@@ -45,4 +49,6 @@ abstract class AbstractFormatter implements FormatterInterface
     abstract protected function formatMergeRequestStatus(MergeRequestStatusResult $result): string;
     abstract protected function formatMergeRequestFiles(MergeRequestFilesResult $result): string;
     abstract protected function formatMergeRequestDiff(MergeRequestDiffResult $result): string;
+    abstract protected function formatGitLabIssue(GitLabIssueResult $result): string;
+    abstract protected function formatGitLabIssues(GitLabIssuesResult $result): string;
 }

--- a/src/Cli/Formatter/LlmFormatter.php
+++ b/src/Cli/Formatter/LlmFormatter.php
@@ -3,6 +3,8 @@
 namespace mglaman\DrupalOrgCli\Formatter;
 
 use mglaman\DrupalOrg\IssueTrait;
+use mglaman\DrupalOrg\Result\GitLab\GitLabIssueResult;
+use mglaman\DrupalOrg\Result\GitLab\GitLabIssuesResult;
 use mglaman\DrupalOrg\Result\Issue\IssueForkResult;
 use mglaman\DrupalOrg\Result\Issue\IssueResult;
 use mglaman\DrupalOrg\Result\Maintainer\MaintainerIssuesResult;
@@ -236,6 +238,63 @@ XML;
   <diff>{$diff}</diff>
 </drupal_context>
 XML;
+    }
+
+    protected function formatGitLabIssue(GitLabIssueResult $result): string
+    {
+        $issue = $result->issue;
+        $title = $this->xmlEscape($issue->title);
+        $state = $this->xmlEscape($issue->state);
+        $author = $this->xmlEscape($issue->author);
+        $createdAt = $this->xmlEscape($issue->createdAt);
+        $updatedAt = $this->xmlEscape($issue->updatedAt);
+        $webUrl = $this->xmlEscape($issue->webUrl);
+        $description = $this->cdataWrap($issue->description);
+
+        $labelsXml = '';
+        foreach ($issue->labels as $label) {
+            $labelsXml .= '    <label>' . $this->xmlEscape($label) . "</label>\n";
+        }
+
+        $assigneesXml = '';
+        foreach ($issue->assignees as $assignee) {
+            $assigneesXml .= '    <assignee>' . $this->xmlEscape($assignee) . "</assignee>\n";
+        }
+
+        return <<<XML
+<gitlab_context>
+  <issue_id>{$issue->iid}</issue_id>
+  <title>{$title}</title>
+  <state>{$state}</state>
+  <author>{$author}</author>
+  <created_at>{$createdAt}</created_at>
+  <updated_at>{$updatedAt}</updated_at>
+  <url>{$webUrl}</url>
+  <labels>
+{$labelsXml}  </labels>
+  <assignees>
+{$assigneesXml}  </assignees>
+  <description>{$description}</description>
+</gitlab_context>
+XML;
+    }
+
+    protected function formatGitLabIssues(GitLabIssuesResult $result): string
+    {
+        $project = $this->xmlEscape($result->projectMachineName);
+        $items = '';
+        foreach ($result->issues as $issue) {
+            $title = $this->xmlEscape($issue->title);
+            $state = $this->xmlEscape($issue->state);
+            $url = $this->xmlEscape($issue->webUrl);
+            $items .= "    <item>\n";
+            $items .= "      <iid>{$issue->iid}</iid>\n";
+            $items .= "      <title>{$title}</title>\n";
+            $items .= "      <state>{$state}</state>\n";
+            $items .= "      <url>{$url}</url>\n";
+            $items .= "    </item>\n";
+        }
+        return "<gitlab_context>\n  <project>{$project}</project>\n  <issues>\n{$items}  </issues>\n</gitlab_context>";
     }
 
     private function toIso8601(int $timestamp): string

--- a/src/Cli/Formatter/MarkdownFormatter.php
+++ b/src/Cli/Formatter/MarkdownFormatter.php
@@ -3,6 +3,8 @@
 namespace mglaman\DrupalOrgCli\Formatter;
 
 use mglaman\DrupalOrg\IssueTrait;
+use mglaman\DrupalOrg\Result\GitLab\GitLabIssueResult;
+use mglaman\DrupalOrg\Result\GitLab\GitLabIssuesResult;
 use mglaman\DrupalOrg\Result\Issue\IssueForkResult;
 use mglaman\DrupalOrg\Result\Issue\IssueResult;
 use mglaman\DrupalOrg\Result\Maintainer\MaintainerIssuesResult;
@@ -185,6 +187,42 @@ class MarkdownFormatter extends AbstractFormatter
         $lines[] = '```diff';
         $lines[] = $result->diff;
         $lines[] = '```';
+        return implode("\n", $lines);
+    }
+
+    protected function formatGitLabIssue(GitLabIssueResult $result): string
+    {
+        $issue = $result->issue;
+        $lines = [];
+        $lines[] = "# {$issue->title}";
+        $lines[] = '';
+        $lines[] = "- **State:** {$issue->state}";
+        $lines[] = "- **Author:** {$issue->author}";
+        if ($issue->assignees !== []) {
+            $lines[] = '- **Assignees:** ' . implode(', ', $issue->assignees);
+        }
+        if ($issue->labels !== []) {
+            $lines[] = '- **Labels:** ' . implode(', ', $issue->labels);
+        }
+        $lines[] = "- **Created:** {$issue->createdAt}";
+        $lines[] = "- **Updated:** {$issue->updatedAt}";
+        $lines[] = "- **URL:** {$issue->webUrl}";
+        $lines[] = '';
+        $lines[] = '## Description';
+        $lines[] = '';
+        $lines[] = $issue->description;
+        return implode("\n", $lines);
+    }
+
+    protected function formatGitLabIssues(GitLabIssuesResult $result): string
+    {
+        $lines = [];
+        $lines[] = "# {$result->projectMachineName}";
+        $lines[] = '';
+        foreach ($result->issues as $issue) {
+            $labels = $issue->labels !== [] ? ' [' . implode(', ', $issue->labels) . ']' : '';
+            $lines[] = "- **#{$issue->iid}** [{$issue->state}]{$labels} [{$issue->title}]({$issue->webUrl})";
+        }
         return implode("\n", $lines);
     }
 }


### PR DESCRIPTION
## Summary

- Detects projects that have migrated to GitLab work items via `field_project_has_issue_queue: false` on the D.o project node
- `project:issues` delegates to `glab issue list` for these projects (shows a stderr notice)
- `issue:show` accepts `git.drupalcode.org/-/work_items/{id}` and `/-/issues/{id}` URLs, fetching via `glab issue view`
- Full `--format=json|md|llm` support via new `GitLabIssueResult` / `GitLabIssuesResult` types and formatter implementations
- Two new MCP tools: `gitlab_issue_show(workItemUrl)` and `gitlab_project_issues(machineName, state, limit)`

**Key detail:** On drupalcode.org, the GitLab `iid` equals the Drupal.org NID, so the number in `/-/work_items/3586157` maps directly to `glab issue view 3586157`.

Requires `glab` CLI installed and authenticated with `git.drupalcode.org`.

Closes #335
Closes #337

## Test plan

- [ ] `./drupalorg project:issues ai_context` — uses glab path, prints notice to stderr
- [ ] `./drupalorg project:issues drupal` — still uses D.o API path
- [ ] `./drupalorg issue:show https://git.drupalcode.org/project/ai_context/-/work_items/3586157`
- [ ] `./drupalorg project:issues ai_context --format=json`
- [ ] `./drupalorg issue:show https://git.drupalcode.org/project/ai_context/-/work_items/3586157 --format=llm`
- [ ] PHPStan + PHPCS + phpunit all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)