### PR TITLE
feat: replace skill:install file copy with discovery stubs + skill:get

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -161,12 +161,13 @@ jobs:
         run: |
           php drupalorg.phar skill:install
           test -f .claude/skills/drupalorg-cli/SKILL.md
-          test -f .claude/skills/drupalorg-issue-search/SKILL.md
-          test -f .claude/skills/drupalorg-issue-summary-update/SKILL.md
-          test -f .claude/skills/drupalorg-work-on-issue/SKILL.md
+          test ! -d .claude/skills/drupalorg-issue-search
+          test ! -d .claude/skills/drupalorg-issue-summary-update
+          test ! -d .claude/skills/drupalorg-work-on-issue
           grep -q "drupalorg skill:get drupalorg-cli" .claude/skills/drupalorg-cli/SKILL.md
       - name: skill:get
         run: |
           php drupalorg.phar skill:get drupalorg-cli | grep -q "## Overview"
           php drupalorg.phar skill:get drupalorg-cli --full | grep -q "## Reference:"
-          php drupalorg.phar skill:get drupalorg-work-on-issue | grep -q "drupalorg skill:get"
+          php drupalorg.phar skill:get drupalorg-issue-search | grep -q "drupalorg-issue-search"
+          php drupalorg.phar skill:get drupalorg-work-on-issue | grep -q "drupalorg-work-on-issue"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -161,6 +161,12 @@ jobs:
         run: |
           php drupalorg.phar skill:install
           test -f .claude/skills/drupalorg-cli/SKILL.md
-          test -f .claude/skills/drupalorg-cli/references/work-on-issue.md
-          test -f .claude/skills/drupalorg-cli/references/patch-contribution.md
-          test -f .claude/skills/drupalorg-cli/references/gitlab-mr-contribution.md
+          test -f .claude/skills/drupalorg-issue-search/SKILL.md
+          test -f .claude/skills/drupalorg-issue-summary-update/SKILL.md
+          test -f .claude/skills/drupalorg-work-on-issue/SKILL.md
+          grep -q "drupalorg skill:get drupalorg-cli" .claude/skills/drupalorg-cli/SKILL.md
+      - name: skill:get
+        run: |
+          php drupalorg.phar skill:get drupalorg-cli | grep -q "## Overview"
+          php drupalorg.phar skill:get drupalorg-cli --full | grep -q "## Reference:"
+          php drupalorg.phar skill:get drupalorg-work-on-issue | grep -q "drupalorg skill:get"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ This CLI reads from Drupal.org and automates local merge request workflows. Its 
 | `project:release-notes` | `prn` | Displays release notes for a release |
 | `project:link` | | Opens project page in browser |
 | `project:kanban` | | Opens project kanban in browser |
+| `skill:install` | | Installs discovery stubs into `.claude/skills/` |
+| `skill:get` | | Outputs current skill content for agent consumption |
 
 ## Architecture
 

--- a/skills/drupalorg-cli/SKILL.md
+++ b/skills/drupalorg-cli/SKILL.md
@@ -207,10 +207,21 @@ drupalorg mr:list [nid] --format=llm --no-cache
 | `Remote … does not exist` | `issue:checkout` run before `issue:setup-remote` | Run `issue:setup-remote <nid>` first |
 | `429 / 503` | Drupal.org rate limit or maintenance | The client retries automatically; wait and retry if it persists |
 
+## Available Skills
+
+Fetch any skill on demand — content always reflects the installed version:
+
+```bash
+drupalorg skill:get drupalorg-cli --full       # CLI reference + workflow references
+drupalorg skill:get drupalorg-issue-search     # Search issues across API, scrape, and web
+drupalorg skill:get drupalorg-issue-summary-update  # Analyse and update issue summaries
+drupalorg skill:get drupalorg-work-on-issue    # End-to-end GitLab MR contribution workflow
+```
+
 ## References
 
-Detailed workflow guides are in the `references/` directory alongside this file:
+Detailed workflow guides available via `--full`:
 
-- `references/work-on-issue.md` — End-to-end GitLab MR workflow ("Work on this issue")
-- `references/patch-contribution.md` — Classic patch-based contribution workflow
-- `references/gitlab-mr-contribution.md` — GitLab MR contribution workflow reference
+- `work-on-issue` — End-to-end GitLab MR workflow ("Work on this issue")
+- `patch-contribution` — Classic patch-based contribution workflow
+- `gitlab-mr-contribution` — GitLab MR contribution workflow reference

--- a/skills/drupalorg-cli/SKILL.md
+++ b/skills/drupalorg-cli/SKILL.md
@@ -175,8 +175,12 @@ drupalorg maintainer:release-notes <ref1> [ref2] [--format=json|md|html]
 ### Utility commands
 
 ```bash
-# Install the drupalorg-cli agent skill into .claude/skills/drupalorg-cli/
+# Install discovery stubs into .claude/skills/ in the current directory
 drupalorg skill:install
+
+# Output current skill content (use instead of reading stale installed files)
+drupalorg skill:get <name>
+drupalorg skill:get <name> --full  # Include reference files
 ```
 
 ## Cache Bypass

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -70,6 +70,7 @@ class Application extends ParentApplication
         $commands[] = new Command\Maintainer\Issues();
         $commands[] = new Command\Maintainer\ReleaseNotes();
         $commands[] = new Command\Skill\Install();
+        $commands[] = new Command\Skill\Get();
         $commands[] = new Command\Issue\GetFork();
         $commands[] = new Command\Issue\SetupRemote();
         $commands[] = new Command\Issue\Checkout();

--- a/src/Cli/Command/Skill/Get.php
+++ b/src/Cli/Command/Skill/Get.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\DrupalOrgCli\Command\Skill;
+
+use mglaman\DrupalOrgCli\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Get extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('skill:get')
+            ->setDescription('Outputs current skill content for agent consumption.')
+            ->addArgument('name', InputArgument::REQUIRED, 'Skill name (e.g. drupalorg-cli)')
+            ->addOption('full', null, InputOption::VALUE_NONE, 'Include reference files');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $name = (string) $input->getArgument('name');
+        $skillFile = __DIR__ . '/../../../../skills/' . $name . '/SKILL.md';
+
+        if (!is_file($skillFile)) {
+            $this->stdErr->writeln(sprintf('<error>Skill not found: %s</error>', $name));
+            $available = $this->getAvailableSkills();
+            if ($available !== []) {
+                $this->stdErr->writeln('Available skills: ' . implode(', ', $available));
+            }
+            return 1;
+        }
+
+        $content = file_get_contents($skillFile);
+        if ($content === false) {
+            $this->stdErr->writeln(sprintf('<error>Could not read skill: %s</error>', $name));
+            return 1;
+        }
+
+        $this->stdOut->write($content);
+
+        if ((bool) $input->getOption('full')) {
+            $refDir = __DIR__ . '/../../../../skills/' . $name . '/references';
+            if (is_dir($refDir)) {
+                foreach (new \DirectoryIterator($refDir) as $fileInfo) {
+                    if ($fileInfo->isDot() || !$fileInfo->isFile() || $fileInfo->getExtension() !== 'md') {
+                        continue;
+                    }
+                    $refContent = file_get_contents($fileInfo->getPathname());
+                    if ($refContent !== false) {
+                        $this->stdOut->writeln('');
+                        $this->stdOut->writeln('---');
+                        $this->stdOut->writeln('## Reference: ' . $fileInfo->getBasename('.md'));
+                        $this->stdOut->writeln('---');
+                        $this->stdOut->writeln('');
+                        $this->stdOut->write($refContent);
+                    }
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getAvailableSkills(): array
+    {
+        $skillsRoot = __DIR__ . '/../../../../skills';
+        if (!is_dir($skillsRoot)) {
+            return [];
+        }
+        $skills = [];
+        foreach (new \DirectoryIterator($skillsRoot) as $dir) {
+            if ($dir->isDot() || !$dir->isDir()) {
+                continue;
+            }
+            $skills[] = $dir->getFilename();
+        }
+        sort($skills);
+        return $skills;
+    }
+}

--- a/src/Cli/Command/Skill/Install.php
+++ b/src/Cli/Command/Skill/Install.php
@@ -19,25 +19,11 @@ class Install extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $skillsRootSrc = __DIR__ . '/../../../../skills';
+        $skillSrc = __DIR__ . '/../../../../skills/drupalorg-cli';
         $cwd = (string) getcwd();
-        $skillsRootDest = $cwd . DIRECTORY_SEPARATOR . '.claude' . DIRECTORY_SEPARATOR . 'skills';
+        $skillDest = $cwd . DIRECTORY_SEPARATOR . '.claude' . DIRECTORY_SEPARATOR . 'skills' . DIRECTORY_SEPARATOR . 'drupalorg-cli';
 
-        foreach (new \DirectoryIterator($skillsRootSrc) as $skillDir) {
-            if ($skillDir->isDot() || !$skillDir->isDir()) {
-                continue;
-            }
-            $result = $this->installDiscoveryStub(
-                $skillDir->getPathname(),
-                $skillDir->getFilename(),
-                $skillsRootDest . DIRECTORY_SEPARATOR . $skillDir->getFilename()
-            );
-            if ($result !== 0) {
-                return $result;
-            }
-        }
-
-        return 0;
+        return $this->installDiscoveryStub($skillSrc, 'drupalorg-cli', $skillDest);
     }
 
     private function installDiscoveryStub(string $srcDir, string $skillName, string $destDir): int

--- a/src/Cli/Command/Skill/Install.php
+++ b/src/Cli/Command/Skill/Install.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace mglaman\DrupalOrgCli\Command\Skill;
 
 use mglaman\DrupalOrgCli\Command\Command;
@@ -8,12 +10,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Install extends Command
 {
-
     protected function configure(): void
     {
         $this
             ->setName('skill:install')
-            ->setDescription('Installs all drupalorg-cli agent skills into .claude/skills/ in the current directory.');
+            ->setDescription('Installs drupalorg-cli discovery skills into .claude/skills/ in the current directory.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -26,8 +27,9 @@ class Install extends Command
             if ($skillDir->isDot() || !$skillDir->isDir()) {
                 continue;
             }
-            $result = $this->installSkill(
+            $result = $this->installDiscoveryStub(
                 $skillDir->getPathname(),
+                $skillDir->getFilename(),
                 $skillsRootDest . DIRECTORY_SEPARATOR . $skillDir->getFilename()
             );
             if ($result !== 0) {
@@ -38,68 +40,62 @@ class Install extends Command
         return 0;
     }
 
-    private function installSkill(string $srcDir, string $destDir): int
+    private function installDiscoveryStub(string $srcDir, string $skillName, string $destDir): int
     {
-        if (!is_dir($destDir) && !mkdir($destDir, 0755, true) && !is_dir($destDir)) {
-            $this->stdErr->writeln(sprintf('<error>Failed to create directory: %s</error>', $destDir));
-            return 1;
-        }
-
         $srcFile = $srcDir . DIRECTORY_SEPARATOR . 'SKILL.md';
-        $destFile = $destDir . DIRECTORY_SEPARATOR . 'SKILL.md';
         $content = file_get_contents($srcFile);
         if ($content === false) {
             $this->stdErr->writeln(sprintf('<error>Could not read skill source: %s</error>', $srcFile));
             return 1;
         }
-        if (file_put_contents($destFile, $content) === false) {
+
+        $stub = $this->buildDiscoveryStub($content, $skillName);
+
+        if (!is_dir($destDir) && !mkdir($destDir, 0755, true) && !is_dir($destDir)) {
+            $this->stdErr->writeln(sprintf('<error>Failed to create directory: %s</error>', $destDir));
+            return 1;
+        }
+
+        $destFile = $destDir . DIRECTORY_SEPARATOR . 'SKILL.md';
+        if (file_put_contents($destFile, $stub) === false) {
             $this->stdErr->writeln(sprintf('<error>Failed to write skill file: %s</error>', $destFile));
             return 1;
         }
         $this->stdOut->writeln(sprintf('<comment>Skill installed to %s</comment>', $destFile));
 
-        $refSrcDir = $srcDir . DIRECTORY_SEPARATOR . 'references';
-        if (!is_dir($refSrcDir)) {
-            return 0;
-        }
-
-        $refDestDir = $destDir . DIRECTORY_SEPARATOR . 'references';
-        if (!is_dir($refDestDir) && !mkdir($refDestDir, 0755, true) && !is_dir($refDestDir)) {
-            $this->stdErr->writeln(sprintf('<error>Failed to create directory: %s</error>', $refDestDir));
-            return 1;
-        }
-
-        try {
-            foreach (new \DirectoryIterator($refSrcDir) as $fileInfo) {
-                if ($fileInfo->isDot() || !$fileInfo->isFile() || $fileInfo->getExtension() !== 'md') {
-                    continue;
-                }
-                $refSrc = $fileInfo->getPathname();
-                $refDest = $refDestDir . DIRECTORY_SEPARATOR . $fileInfo->getFilename();
-                if (!copy($refSrc, $refDest)) {
-                    $lastError = error_get_last();
-                    $errorDetail = (is_array($lastError) && $lastError['message'] !== '')
-                        ? ' Underlying error: ' . $lastError['message']
-                        : '';
-                    $this->stdErr->writeln(sprintf(
-                        '<error>Failed to copy reference file from %s to %s.%s</error>',
-                        $refSrc,
-                        $refDest,
-                        $errorDetail
-                    ));
-                    return 1;
-                }
-                $this->stdOut->writeln(sprintf('<comment>Reference installed to %s</comment>', $refDest));
-            }
-        } catch (\UnexpectedValueException $e) {
-            $this->stdErr->writeln(sprintf(
-                '<error>Failed to read skill references directory: %s (%s)</error>',
-                $refSrcDir,
-                $e->getMessage()
-            ));
-            return 1;
-        }
-
         return 0;
+    }
+
+    private function buildDiscoveryStub(string $sourceContent, string $skillName): string
+    {
+        // Extract frontmatter block (name + description for trigger matching).
+        // Preserve it verbatim — the description is what Claude Code uses to
+        // decide whether to invoke the skill.
+        $frontmatter = '';
+        if (preg_match('/^---\n(.*?)\n---/s', $sourceContent, $matches)) {
+            $frontmatter = $matches[1];
+        }
+
+        // Add allowed-tools so agents can call drupalorg without extra prompts.
+        if (!str_contains($frontmatter, 'allowed-tools:')) {
+            $frontmatter .= "\nallowed-tools: Bash(drupalorg:*), Bash(drupalorg skill:*)";
+        }
+
+        $hasReferences = is_dir(__DIR__ . '/../../../../skills/' . $skillName . '/references');
+        $fullFlag = $hasReferences ? "\ndrupalorg skill:get {$skillName} --full  # Include reference files" : '';
+
+        return <<<MD
+---
+{$frontmatter}
+---
+
+**Run `drupalorg skill:get {$skillName}` before using this skill.**
+This stub does not contain instructions — they are served by the CLI and always reflect the installed version.
+
+```bash
+drupalorg skill:get {$skillName}{$fullFlag}
+```
+
+MD;
     }
 }

--- a/tests/src/Command/Skill/GetTest.php
+++ b/tests/src/Command/Skill/GetTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace mglaman\DrupalOrg\Tests\Command\Skill;
+
+use mglaman\DrupalOrgCli\Command\Skill\Get;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Get::class)]
+class GetTest extends TestCase
+{
+    public function testClassExists(): void
+    {
+        $command = new Get();
+        self::assertInstanceOf(Get::class, $command);
+        self::assertSame('skill:get', $command->getName());
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #334
- `skill:install` now writes thin discovery stubs instead of copying full SKILL.md files — installed skills never go stale when the phar is updated
- New `skill:get <name>` command outputs current skill content from the phar; `--full` appends reference files
- Stubs preserve original `name`/`description` frontmatter (trigger matching intact) and add `allowed-tools: Bash(drupalorg:*)` so agents can invoke the CLI without extra permission prompts

## How it works

Mirrors the [agent-browser discovery pattern](https://agent-browser.dev/skills). The installed stub is just a redirect:

```
drupalorg skill:get drupalorg-cli
drupalorg skill:get drupalorg-cli --full  # includes references/
```

Agents fetch instructions on demand from the installed binary — always current, no re-install needed after upgrades.

## Test plan

- [ ] `drupalorg skill:install` — verify stubs written to `.claude/skills/`, no reference dirs copied
- [ ] `drupalorg skill:get drupalorg-cli` — outputs full SKILL.md
- [ ] `drupalorg skill:get drupalorg-cli --full` — outputs SKILL.md + reference files
- [ ] `drupalorg skill:get nonexistent` — exits 1 with available skills listed
- [ ] `vendor/bin/phpstan analyse src` — no errors
- [ ] `vendor/bin/phpcs src` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)