### PR TITLE
feat: add issue:fork/assign/label commands for GitLab work item bot

### DIFF
--- a/skill-data/drupalorg-cli/SKILL.md
+++ b/skill-data/drupalorg-cli/SKILL.md
@@ -131,6 +131,39 @@ drupalorg mr:logs <nid> <mr-iid>
 drupalorg mr:logs 'project/drupal!708'
 ```
 
+### Slash commands (GitLab work items only)
+
+These commands post Drupal.org bot quick-actions as comments on a GitLab work item.
+They only work for projects whose issue queue lives at `git.drupalcode.org` (the bot
+is not present on classic Drupal.org issue queues).
+
+The `<ref>` argument is a WorkItemRef — bare NID, `project_name#nid`, or full URL.
+
+Each command also accepts `--format=text|json|md|llm`. Posting is asynchronous: the
+bot processes the comment after it lands, so re-fetch with `--no-cache` to confirm.
+
+```bash
+# Create a fork (and a default-branch issue branch) for an issue without a fork
+drupalorg issue:fork <ref>
+
+# Grant the current user push access to the existing fork
+drupalorg issue:get-access <ref>
+
+# Assign one or more users (default: me)
+drupalorg issue:assign <ref> [user...]
+drupalorg issue:unassign <ref> [user...]
+drupalorg issue:reassign <ref> <user> [user...]
+
+# Manage labels (e.g. state::needsReview, state::rtbc, state::needsWork)
+drupalorg issue:label <ref> <label> [label...]
+drupalorg issue:unlabel <ref> <label> [label...]
+drupalorg issue:relabel <ref> <label> [label...]
+```
+
+Authentication requires a GitLab token. The CLI reads `DRUPALORG_GITLAB_TOKEN` and
+falls back to `glab config get token --host git.drupalcode.org` when that env var is
+unset.
+
 ### Project commands
 
 ```bash

--- a/skill-data/drupalorg-work-on-issue/SKILL.md
+++ b/skill-data/drupalorg-work-on-issue/SKILL.md
@@ -53,6 +53,20 @@ asking the user if `CLAUDE.md` provides no guidance.
 - **No matches** → note that no branches exist yet and ask the user how to proceed
   (e.g. create a new branch from the upstream project default branch).
 
+**No fork at all (GitLab work item projects):** If `issue:get-fork` reports no fork
+exists AND the project uses GitLab work items (the ref is a `project_name#nid` or
+work item URL, not a classic Drupal.org NID), offer to create one:
+
+```bash
+drupalorg issue:fork <ref>
+```
+
+The Drupal.org bot processes the comment asynchronously. Wait a few seconds, then
+re-run `drupalorg issue:get-fork <ref> --format=llm --no-cache` to confirm the fork
+exists before proceeding. To pick up an existing fork you don't yet have push access
+to (Example #2 in the upstream docs), run `drupalorg issue:get-access <ref>` before
+`issue:setup-remote`.
+
 **[PAUSE]** Only pause here if the working directory could not be determined automatically
 OR if multiple branches exist. Present your findings and wait for confirmation before
 proceeding.
@@ -70,6 +84,13 @@ Once the directory and branch are confirmed:
 ```bash
 drupalorg issue:setup-remote <nid>
 drupalorg issue:checkout <nid> <branch>
+```
+
+**Optional (GitLab work items):** Self-assign so others can see you are working on
+this issue:
+
+```bash
+drupalorg issue:assign <ref>
 ```
 
 **SSH remote URL check:** `issue:setup-remote` sets the remote URL to HTTPS
@@ -176,6 +197,14 @@ Iterate until the pipeline is green or the user asks to stop:
 
 **[PAUSE]** After each push, report the pipeline outcome and ask whether to continue
 or stop.
+
+**Hand off for review (GitLab work items only):** When the pipeline is green and the
+user confirms the work is ready for review, flip the state label and unassign:
+
+```bash
+drupalorg issue:label <ref> state::needsReview
+drupalorg issue:unassign <ref>
+```
 
 ---
 

--- a/src/Api/Action/GitLab/PostWorkItemSlashCommandAction.php
+++ b/src/Api/Action/GitLab/PostWorkItemSlashCommandAction.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\DrupalOrg\Action\GitLab;
+
+use mglaman\DrupalOrg\Client;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
+use mglaman\DrupalOrg\GitLab\WorkItemRef;
+use mglaman\DrupalOrg\Result\Issue\SlashCommandResult;
+
+/**
+ * Posts a Drupal.org bot slash command (e.g. `/do:fork`, `/do:assign me`,
+ * `/do:label ~state::needsReview`) as a comment on a GitLab work item.
+ *
+ * Only meaningful for projects whose issue queue has been migrated to GitLab
+ * work items at git.drupalcode.org. For classic Drupal.org issue queues the
+ * bot is not present and the call will 404.
+ */
+class PostWorkItemSlashCommandAction
+{
+    public function __construct(
+        private readonly Client $client,
+        private readonly GitLabClient $gitLabClient,
+    ) {
+    }
+
+    public function __invoke(string $refOrNid, string $command): SlashCommandResult
+    {
+        $ref = $this->resolveRef($refOrNid);
+
+        try {
+            $response = $this->gitLabClient->postIssueNote(
+                $ref->projectPath,
+                $ref->issueId,
+                $command,
+            );
+        } catch (\Exception $e) {
+            throw new \RuntimeException(sprintf(
+                'Failed to post "%s" to %s#%d: %s. If this project still uses a '
+                . 'Drupal.org issue queue, slash commands are not supported.',
+                $command,
+                $ref->projectPath,
+                $ref->issueId,
+                $e->getMessage(),
+            ), 0, $e);
+        }
+
+        $noteId = isset($response->id) ? (int) $response->id : 0;
+
+        return new SlashCommandResult(
+            projectPath: $ref->projectPath,
+            issueIid: $ref->issueId,
+            command: $command,
+            noteId: $noteId,
+        );
+    }
+
+    private function resolveRef(string $refOrNid): WorkItemRef
+    {
+        $ref = WorkItemRef::tryParse($refOrNid);
+        if ($ref !== null) {
+            return $ref;
+        }
+        if (!ctype_digit($refOrNid)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Unrecognised work item reference "%s". Expected a NID, '
+                . 'shorthand (project_name#nid), or full work item URL.',
+                $refOrNid,
+            ));
+        }
+        $node = $this->client->getNode($refOrNid);
+        $machineName = $node->fieldProjectMachineName;
+        if ($machineName === '') {
+            throw new \RuntimeException(sprintf(
+                'Could not resolve project for NID %s.',
+                $refOrNid,
+            ));
+        }
+        return new WorkItemRef(
+            projectPath: 'project/' . $machineName,
+            issueId: (int) $refOrNid,
+        );
+    }
+}

--- a/src/Api/Action/GitLab/PostWorkItemSlashCommandAction.php
+++ b/src/Api/Action/GitLab/PostWorkItemSlashCommandAction.php
@@ -46,23 +46,31 @@ class PostWorkItemSlashCommandAction
             ), 0, $e);
         }
 
-        $noteId = isset($response->id) ? (int) $response->id : 0;
+        if (!isset($response->id) || !is_numeric($response->id)) {
+            throw new \RuntimeException(sprintf(
+                'GitLab note response for %s#%d did not contain an id. The '
+                . 'note may not have been posted.',
+                $ref->projectPath,
+                $ref->issueId,
+            ));
+        }
 
         return new SlashCommandResult(
             projectPath: $ref->projectPath,
             issueIid: $ref->issueId,
             command: $command,
-            noteId: $noteId,
+            noteId: (int) $response->id,
         );
     }
 
     private function resolveRef(string $refOrNid): WorkItemRef
     {
+        $refOrNid = trim($refOrNid);
         $ref = WorkItemRef::tryParse($refOrNid);
         if ($ref !== null) {
             return $ref;
         }
-        if (!ctype_digit($refOrNid)) {
+        if ($refOrNid === '' || !ctype_digit($refOrNid)) {
             throw new \InvalidArgumentException(sprintf(
                 'Unrecognised work item reference "%s". Expected a NID, '
                 . 'shorthand (project_name#nid), or full work item URL.',

--- a/src/Api/GitLab/Client.php
+++ b/src/Api/GitLab/Client.php
@@ -4,6 +4,7 @@ namespace mglaman\DrupalOrg\GitLab;
 
 use GuzzleHttp\HandlerStack;
 use GuzzleRetry\GuzzleRetryMiddleware;
+use Symfony\Component\Process\Process;
 
 class Client
 {
@@ -25,8 +26,8 @@ class Client
             'Accept' => 'application/json',
         ];
 
-        $token = getenv('DRUPALORG_GITLAB_TOKEN');
-        if ($token !== false && $token !== '') {
+        $token = self::resolveToken();
+        if ($token !== null) {
             $headers['PRIVATE-TOKEN'] = $token;
         }
 
@@ -35,6 +36,30 @@ class Client
             'handler' => $stack,
             'headers' => $headers,
         ]);
+    }
+
+    /**
+     * Resolve a GitLab token from env or, as a fallback, the glab CLI.
+     */
+    private static function resolveToken(): ?string
+    {
+        $token = getenv('DRUPALORG_GITLAB_TOKEN');
+        if ($token !== false && $token !== '') {
+            return $token;
+        }
+        try {
+            $process = new Process(['glab', 'config', 'get', 'token', '--host', 'git.drupalcode.org']);
+            $process->run();
+            if ($process->isSuccessful()) {
+                $output = trim($process->getOutput());
+                if ($output !== '') {
+                    return $output;
+                }
+            }
+        } catch (\Throwable) {
+            // glab not installed or failed; treat as unauthenticated.
+        }
+        return null;
     }
 
     /**
@@ -52,6 +77,40 @@ class Client
             return \json_decode($res->getBody()->getContents(), false, 512, JSON_THROW_ON_ERROR);
         }
         throw new \Exception('GitLab API error', $res->getStatusCode());
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     * @throws \Exception
+     */
+    private function post(string $path, array $body): mixed
+    {
+        $res = $this->client->request('POST', $path, ['json' => $body]);
+        $status = $res->getStatusCode();
+        if ($status === 200 || $status === 201) {
+            return \json_decode($res->getBody()->getContents(), false, 512, JSON_THROW_ON_ERROR);
+        }
+        throw new \Exception('GitLab API error', $status);
+    }
+
+    /**
+     * POST /projects/{path}/issues/{iid}/notes
+     *
+     * Posts a note (comment) to a GitLab issue or work item. Used to send
+     * Drupal.org bot slash commands such as `/do:fork`, `/do:assign me`, and
+     * `/do:label ~state::needsReview` on projects whose issue queue lives on
+     * GitLab work items.
+     *
+     * @throws \Exception
+     */
+    public function postIssueNote(string $projectPath, int $iid, string $body): \stdClass
+    {
+        /** @var \stdClass $result */
+        $result = $this->post(
+            'projects/' . urlencode($projectPath) . '/issues/' . $iid . '/notes',
+            ['body' => $body],
+        );
+        return $result;
     }
 
     /**

--- a/src/Api/GitLab/SlashCommand.php
+++ b/src/Api/GitLab/SlashCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\DrupalOrg\GitLab;
+
+/**
+ * Builds the comment bodies the Drupal.org bot recognises on GitLab work items.
+ *
+ * See https://new.drupal.org/drupalorg/gitlab-custom-commands.
+ */
+final class SlashCommand
+{
+    public static function fork(): string
+    {
+        return '/do:fork';
+    }
+
+    public static function access(): string
+    {
+        return '/do:access';
+    }
+
+    /**
+     * @param array<int, string> $users
+     */
+    public static function assign(array $users): string
+    {
+        return '/do:assign ' . self::formatUsers($users);
+    }
+
+    /**
+     * @param array<int, string> $users
+     */
+    public static function unassign(array $users): string
+    {
+        return '/do:unassign ' . self::formatUsers($users);
+    }
+
+    /**
+     * @param array<int, string> $users
+     */
+    public static function reassign(array $users): string
+    {
+        return '/do:reassign ' . self::formatUsers($users);
+    }
+
+    /**
+     * @param array<int, string> $labels
+     */
+    public static function label(array $labels): string
+    {
+        return '/do:label ' . self::formatLabels($labels);
+    }
+
+    /**
+     * @param array<int, string> $labels
+     */
+    public static function unlabel(array $labels): string
+    {
+        return '/do:unlabel ' . self::formatLabels($labels);
+    }
+
+    /**
+     * @param array<int, string> $labels
+     */
+    public static function relabel(array $labels): string
+    {
+        return '/do:relabel ' . self::formatLabels($labels);
+    }
+
+    /**
+     * @param array<int, string> $users
+     */
+    private static function formatUsers(array $users): string
+    {
+        if ($users === []) {
+            throw new \InvalidArgumentException('At least one user is required.');
+        }
+        return implode(' ', array_map(self::formatUser(...), $users));
+    }
+
+    private static function formatUser(string $user): string
+    {
+        $user = ltrim(trim($user), '@');
+        if ($user === '') {
+            throw new \InvalidArgumentException('User name cannot be empty.');
+        }
+        return $user === 'me' ? 'me' : '@' . $user;
+    }
+
+    /**
+     * @param array<int, string> $labels
+     */
+    private static function formatLabels(array $labels): string
+    {
+        if ($labels === []) {
+            throw new \InvalidArgumentException('At least one label is required.');
+        }
+        return implode(' ', array_map(self::formatLabel(...), $labels));
+    }
+
+    private static function formatLabel(string $label): string
+    {
+        $label = ltrim(trim($label), '~');
+        if ($label === '') {
+            throw new \InvalidArgumentException('Label cannot be empty.');
+        }
+        return '~' . $label;
+    }
+}

--- a/src/Api/Result/Issue/SlashCommandResult.php
+++ b/src/Api/Result/Issue/SlashCommandResult.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\DrupalOrg\Result\Issue;
+
+use mglaman\DrupalOrg\Result\ResultInterface;
+
+class SlashCommandResult implements ResultInterface
+{
+    public function __construct(
+        public readonly string $projectPath,
+        public readonly int $issueIid,
+        public readonly string $command,
+        public readonly int $noteId,
+    ) {
+    }
+
+    public function workItemUrl(): string
+    {
+        return sprintf(
+            'https://git.drupalcode.org/%s/-/work_items/%d',
+            $this->projectPath,
+            $this->issueIid,
+        );
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'project_path' => $this->projectPath,
+            'issue_iid' => $this->issueIid,
+            'command' => $this->command,
+            'note_id' => $this->noteId,
+            'url' => $this->workItemUrl(),
+        ];
+    }
+}

--- a/src/Api/Result/Issue/SlashCommandResult.php
+++ b/src/Api/Result/Issue/SlashCommandResult.php
@@ -16,6 +16,14 @@ class SlashCommandResult implements ResultInterface
     ) {
     }
 
+    /**
+     * Canonical work item URL on git.drupalcode.org.
+     *
+     * Drupal.org redirects `/-/issues/{iid}` to `/-/work_items/{iid}`, so this
+     * always emits the `work_items` form even when the caller supplied an
+     * `/-/issues/` URL (which {@see WorkItemRef::tryParse()} accepts for input
+     * convenience). Slash commands only have meaning on work items.
+     */
     public function workItemUrl(): string
     {
         return sprintf(

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -74,6 +74,14 @@ class Application extends ParentApplication
         $commands[] = new Command\Issue\GetFork();
         $commands[] = new Command\Issue\SetupRemote();
         $commands[] = new Command\Issue\Checkout();
+        $commands[] = new Command\Issue\Fork();
+        $commands[] = new Command\Issue\GetAccess();
+        $commands[] = new Command\Issue\Assign();
+        $commands[] = new Command\Issue\Unassign();
+        $commands[] = new Command\Issue\Reassign();
+        $commands[] = new Command\Issue\Label();
+        $commands[] = new Command\Issue\Unlabel();
+        $commands[] = new Command\Issue\Relabel();
         $commands[] = new Command\MergeRequest\ListMergeRequests();
         $commands[] = new Command\MergeRequest\GetDiff();
         $commands[] = new Command\MergeRequest\GetFiles();

--- a/src/Cli/Command/Issue/Assign.php
+++ b/src/Cli/Command/Issue/Assign.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace mglaman\DrupalOrgCli\Command\Issue;
+
+use mglaman\DrupalOrg\Action\GitLab\PostWorkItemSlashCommandAction;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
+use mglaman\DrupalOrg\GitLab\SlashCommand;
+use mglaman\DrupalOrgCli\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Assign extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('issue:assign')
+            ->addArgument('ref', InputArgument::REQUIRED, 'Work item ref: NID, project#nid, or full URL')
+            ->addArgument('users', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Usernames to assign (default: me)', ['me'])
+            ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text, json, md, llm.', 'text')
+            ->setDescription('Post /do:assign on a GitLab work item.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $ref = (string) $this->stdIn->getArgument('ref');
+        /** @var array<int, string> $users */
+        $users = $this->stdIn->getArgument('users');
+
+        $action = new PostWorkItemSlashCommandAction($this->client, new GitLabClient());
+        $result = $action($ref, SlashCommand::assign($users));
+
+        $format = (string) $this->stdIn->getOption('format');
+        if ($this->writeFormatted($result, $format)) {
+            return 0;
+        }
+        $this->stdOut->writeln(sprintf(
+            'Posted %s on %s (note #%d).',
+            $result->command,
+            $result->workItemUrl(),
+            $result->noteId,
+        ));
+        return 0;
+    }
+}

--- a/src/Cli/Command/Issue/Fork.php
+++ b/src/Cli/Command/Issue/Fork.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace mglaman\DrupalOrgCli\Command\Issue;
+
+use mglaman\DrupalOrg\Action\GitLab\PostWorkItemSlashCommandAction;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
+use mglaman\DrupalOrg\GitLab\SlashCommand;
+use mglaman\DrupalOrgCli\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Fork extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('issue:fork')
+            ->addArgument('ref', InputArgument::REQUIRED, 'Work item ref: NID, project#nid, or full URL')
+            ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text, json, md, llm.', 'text')
+            ->setDescription('Post /do:fork on a GitLab work item to create a fork.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $ref = (string) $this->stdIn->getArgument('ref');
+        $action = new PostWorkItemSlashCommandAction($this->client, new GitLabClient());
+        $result = $action($ref, SlashCommand::fork());
+
+        $format = (string) $this->stdIn->getOption('format');
+        if ($this->writeFormatted($result, $format)) {
+            return 0;
+        }
+        $this->stdOut->writeln(sprintf(
+            'Posted %s on %s (note #%d). The Drupal.org bot processes the comment asynchronously.',
+            $result->command,
+            $result->workItemUrl(),
+            $result->noteId,
+        ));
+        return 0;
+    }
+}

--- a/src/Cli/Command/Issue/GetAccess.php
+++ b/src/Cli/Command/Issue/GetAccess.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace mglaman\DrupalOrgCli\Command\Issue;
+
+use mglaman\DrupalOrg\Action\GitLab\PostWorkItemSlashCommandAction;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
+use mglaman\DrupalOrg\GitLab\SlashCommand;
+use mglaman\DrupalOrgCli\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GetAccess extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('issue:get-access')
+            ->addArgument('ref', InputArgument::REQUIRED, 'Work item ref: NID, project#nid, or full URL')
+            ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text, json, md, llm.', 'text')
+            ->setDescription('Post /do:access on a GitLab work item to gain push access to its fork.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $ref = (string) $this->stdIn->getArgument('ref');
+        $action = new PostWorkItemSlashCommandAction($this->client, new GitLabClient());
+        $result = $action($ref, SlashCommand::access());
+
+        $format = (string) $this->stdIn->getOption('format');
+        if ($this->writeFormatted($result, $format)) {
+            return 0;
+        }
+        $this->stdOut->writeln(sprintf(
+            'Posted %s on %s (note #%d).',
+            $result->command,
+            $result->workItemUrl(),
+            $result->noteId,
+        ));
+        return 0;
+    }
+}

--- a/src/Cli/Command/Issue/Label.php
+++ b/src/Cli/Command/Issue/Label.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace mglaman\DrupalOrgCli\Command\Issue;
+
+use mglaman\DrupalOrg\Action\GitLab\PostWorkItemSlashCommandAction;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
+use mglaman\DrupalOrg\GitLab\SlashCommand;
+use mglaman\DrupalOrgCli\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Label extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('issue:label')
+            ->addArgument('ref', InputArgument::REQUIRED, 'Work item ref: NID, project#nid, or full URL')
+            ->addArgument('labels', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'Labels to add (e.g. state::needsReview)')
+            ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text, json, md, llm.', 'text')
+            ->setDescription('Post /do:label on a GitLab work item to add labels.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $ref = (string) $this->stdIn->getArgument('ref');
+        /** @var array<int, string> $labels */
+        $labels = $this->stdIn->getArgument('labels');
+
+        $action = new PostWorkItemSlashCommandAction($this->client, new GitLabClient());
+        $result = $action($ref, SlashCommand::label($labels));
+
+        $format = (string) $this->stdIn->getOption('format');
+        if ($this->writeFormatted($result, $format)) {
+            return 0;
+        }
+        $this->stdOut->writeln(sprintf(
+            'Posted %s on %s (note #%d).',
+            $result->command,
+            $result->workItemUrl(),
+            $result->noteId,
+        ));
+        return 0;
+    }
+}

--- a/src/Cli/Command/Issue/Reassign.php
+++ b/src/Cli/Command/Issue/Reassign.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace mglaman\DrupalOrgCli\Command\Issue;
+
+use mglaman\DrupalOrg\Action\GitLab\PostWorkItemSlashCommandAction;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
+use mglaman\DrupalOrg\GitLab\SlashCommand;
+use mglaman\DrupalOrgCli\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Reassign extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('issue:reassign')
+            ->addArgument('ref', InputArgument::REQUIRED, 'Work item ref: NID, project#nid, or full URL')
+            ->addArgument('users', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'Usernames to assign (replaces current)')
+            ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text, json, md, llm.', 'text')
+            ->setDescription('Post /do:reassign on a GitLab work item.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $ref = (string) $this->stdIn->getArgument('ref');
+        /** @var array<int, string> $users */
+        $users = $this->stdIn->getArgument('users');
+
+        $action = new PostWorkItemSlashCommandAction($this->client, new GitLabClient());
+        $result = $action($ref, SlashCommand::reassign($users));
+
+        $format = (string) $this->stdIn->getOption('format');
+        if ($this->writeFormatted($result, $format)) {
+            return 0;
+        }
+        $this->stdOut->writeln(sprintf(
+            'Posted %s on %s (note #%d).',
+            $result->command,
+            $result->workItemUrl(),
+            $result->noteId,
+        ));
+        return 0;
+    }
+}

--- a/src/Cli/Command/Issue/Relabel.php
+++ b/src/Cli/Command/Issue/Relabel.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace mglaman\DrupalOrgCli\Command\Issue;
+
+use mglaman\DrupalOrg\Action\GitLab\PostWorkItemSlashCommandAction;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
+use mglaman\DrupalOrg\GitLab\SlashCommand;
+use mglaman\DrupalOrgCli\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Relabel extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('issue:relabel')
+            ->addArgument('ref', InputArgument::REQUIRED, 'Work item ref: NID, project#nid, or full URL')
+            ->addArgument('labels', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'Labels to set (replaces current)')
+            ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text, json, md, llm.', 'text')
+            ->setDescription('Post /do:relabel on a GitLab work item to reset labels.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $ref = (string) $this->stdIn->getArgument('ref');
+        /** @var array<int, string> $labels */
+        $labels = $this->stdIn->getArgument('labels');
+
+        $action = new PostWorkItemSlashCommandAction($this->client, new GitLabClient());
+        $result = $action($ref, SlashCommand::relabel($labels));
+
+        $format = (string) $this->stdIn->getOption('format');
+        if ($this->writeFormatted($result, $format)) {
+            return 0;
+        }
+        $this->stdOut->writeln(sprintf(
+            'Posted %s on %s (note #%d).',
+            $result->command,
+            $result->workItemUrl(),
+            $result->noteId,
+        ));
+        return 0;
+    }
+}

--- a/src/Cli/Command/Issue/Unassign.php
+++ b/src/Cli/Command/Issue/Unassign.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace mglaman\DrupalOrgCli\Command\Issue;
+
+use mglaman\DrupalOrg\Action\GitLab\PostWorkItemSlashCommandAction;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
+use mglaman\DrupalOrg\GitLab\SlashCommand;
+use mglaman\DrupalOrgCli\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Unassign extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('issue:unassign')
+            ->addArgument('ref', InputArgument::REQUIRED, 'Work item ref: NID, project#nid, or full URL')
+            ->addArgument('users', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Usernames to unassign (default: me)', ['me'])
+            ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text, json, md, llm.', 'text')
+            ->setDescription('Post /do:unassign on a GitLab work item.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $ref = (string) $this->stdIn->getArgument('ref');
+        /** @var array<int, string> $users */
+        $users = $this->stdIn->getArgument('users');
+
+        $action = new PostWorkItemSlashCommandAction($this->client, new GitLabClient());
+        $result = $action($ref, SlashCommand::unassign($users));
+
+        $format = (string) $this->stdIn->getOption('format');
+        if ($this->writeFormatted($result, $format)) {
+            return 0;
+        }
+        $this->stdOut->writeln(sprintf(
+            'Posted %s on %s (note #%d).',
+            $result->command,
+            $result->workItemUrl(),
+            $result->noteId,
+        ));
+        return 0;
+    }
+}

--- a/src/Cli/Command/Issue/Unlabel.php
+++ b/src/Cli/Command/Issue/Unlabel.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace mglaman\DrupalOrgCli\Command\Issue;
+
+use mglaman\DrupalOrg\Action\GitLab\PostWorkItemSlashCommandAction;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
+use mglaman\DrupalOrg\GitLab\SlashCommand;
+use mglaman\DrupalOrgCli\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Unlabel extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('issue:unlabel')
+            ->addArgument('ref', InputArgument::REQUIRED, 'Work item ref: NID, project#nid, or full URL')
+            ->addArgument('labels', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'Labels to remove')
+            ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text, json, md, llm.', 'text')
+            ->setDescription('Post /do:unlabel on a GitLab work item to remove labels.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $ref = (string) $this->stdIn->getArgument('ref');
+        /** @var array<int, string> $labels */
+        $labels = $this->stdIn->getArgument('labels');
+
+        $action = new PostWorkItemSlashCommandAction($this->client, new GitLabClient());
+        $result = $action($ref, SlashCommand::unlabel($labels));
+
+        $format = (string) $this->stdIn->getOption('format');
+        if ($this->writeFormatted($result, $format)) {
+            return 0;
+        }
+        $this->stdOut->writeln(sprintf(
+            'Posted %s on %s (note #%d).',
+            $result->command,
+            $result->workItemUrl(),
+            $result->noteId,
+        ));
+        return 0;
+    }
+}

--- a/src/Cli/Formatter/AbstractFormatter.php
+++ b/src/Cli/Formatter/AbstractFormatter.php
@@ -6,6 +6,7 @@ use mglaman\DrupalOrg\Result\GitLab\GitLabIssueResult;
 use mglaman\DrupalOrg\Result\GitLab\GitLabIssuesResult;
 use mglaman\DrupalOrg\Result\Issue\IssueForkResult;
 use mglaman\DrupalOrg\Result\Issue\IssueResult;
+use mglaman\DrupalOrg\Result\Issue\SlashCommandResult;
 use mglaman\DrupalOrg\Result\Maintainer\MaintainerIssuesResult;
 use mglaman\DrupalOrg\Result\MergeRequest\MergeRequestDiffResult;
 use mglaman\DrupalOrg\Result\MergeRequest\MergeRequestFilesResult;
@@ -33,6 +34,7 @@ abstract class AbstractFormatter implements FormatterInterface
             $result instanceof MergeRequestDiffResult => $this->formatMergeRequestDiff($result),
             $result instanceof GitLabIssueResult => $this->formatGitLabIssue($result),
             $result instanceof GitLabIssuesResult => $this->formatGitLabIssues($result),
+            $result instanceof SlashCommandResult => $this->formatSlashCommand($result),
             default => throw new \InvalidArgumentException(
                 sprintf('Unsupported result type: %s', get_class($result))
             ),
@@ -51,4 +53,5 @@ abstract class AbstractFormatter implements FormatterInterface
     abstract protected function formatMergeRequestDiff(MergeRequestDiffResult $result): string;
     abstract protected function formatGitLabIssue(GitLabIssueResult $result): string;
     abstract protected function formatGitLabIssues(GitLabIssuesResult $result): string;
+    abstract protected function formatSlashCommand(SlashCommandResult $result): string;
 }

--- a/src/Cli/Formatter/LlmFormatter.php
+++ b/src/Cli/Formatter/LlmFormatter.php
@@ -7,6 +7,7 @@ use mglaman\DrupalOrg\Result\GitLab\GitLabIssueResult;
 use mglaman\DrupalOrg\Result\GitLab\GitLabIssuesResult;
 use mglaman\DrupalOrg\Result\Issue\IssueForkResult;
 use mglaman\DrupalOrg\Result\Issue\IssueResult;
+use mglaman\DrupalOrg\Result\Issue\SlashCommandResult;
 use mglaman\DrupalOrg\Result\Maintainer\MaintainerIssuesResult;
 use mglaman\DrupalOrg\Result\MergeRequest\MergeRequestDiffResult;
 use mglaman\DrupalOrg\Result\MergeRequest\MergeRequestFilesResult;
@@ -295,6 +296,23 @@ XML;
             $items .= "    </item>\n";
         }
         return "<gitlab_context>\n  <project>{$project}</project>\n  <issues>\n{$items}  </issues>\n</gitlab_context>";
+    }
+
+    protected function formatSlashCommand(SlashCommandResult $result): string
+    {
+        $projectPath = $this->xmlEscape($result->projectPath);
+        $command = $this->xmlEscape($result->command);
+        $url = $this->xmlEscape($result->workItemUrl());
+
+        return <<<XML
+<drupal_context>
+  <project_path>{$projectPath}</project_path>
+  <issue_iid>{$result->issueIid}</issue_iid>
+  <command>{$command}</command>
+  <note_id>{$result->noteId}</note_id>
+  <url>{$url}</url>
+</drupal_context>
+XML;
     }
 
     private function toIso8601(int $timestamp): string

--- a/src/Cli/Formatter/MarkdownFormatter.php
+++ b/src/Cli/Formatter/MarkdownFormatter.php
@@ -7,6 +7,7 @@ use mglaman\DrupalOrg\Result\GitLab\GitLabIssueResult;
 use mglaman\DrupalOrg\Result\GitLab\GitLabIssuesResult;
 use mglaman\DrupalOrg\Result\Issue\IssueForkResult;
 use mglaman\DrupalOrg\Result\Issue\IssueResult;
+use mglaman\DrupalOrg\Result\Issue\SlashCommandResult;
 use mglaman\DrupalOrg\Result\Maintainer\MaintainerIssuesResult;
 use mglaman\DrupalOrg\Result\MergeRequest\MergeRequestDiffResult;
 use mglaman\DrupalOrg\Result\MergeRequest\MergeRequestFilesResult;
@@ -224,5 +225,17 @@ class MarkdownFormatter extends AbstractFormatter
             $lines[] = "- **#{$issue->iid}** [{$issue->state}]{$labels} [{$issue->title}]({$issue->webUrl})";
         }
         return implode("\n", $lines);
+    }
+
+    protected function formatSlashCommand(SlashCommandResult $result): string
+    {
+        return sprintf(
+            "Posted `%s` on [%s#%d](%s) (note #%d).",
+            $result->command,
+            $result->projectPath,
+            $result->issueIid,
+            $result->workItemUrl(),
+            $result->noteId,
+        );
     }
 }

--- a/tests/src/Action/GitLab/PostWorkItemSlashCommandActionTest.php
+++ b/tests/src/Action/GitLab/PostWorkItemSlashCommandActionTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\DrupalOrg\Tests\Action\GitLab;
+
+use mglaman\DrupalOrg\Action\GitLab\PostWorkItemSlashCommandAction;
+use mglaman\DrupalOrg\Client;
+use mglaman\DrupalOrg\Entity\IssueNode;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
+use mglaman\DrupalOrg\Result\Issue\SlashCommandResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PostWorkItemSlashCommandAction::class)]
+#[CoversClass(SlashCommandResult::class)]
+class PostWorkItemSlashCommandActionTest extends TestCase
+{
+    private static function makeIssueNode(): IssueNode
+    {
+        return new IssueNode(
+            nid: '3586157',
+            title: 'Example AI context issue',
+            created: 1693195104,
+            changed: 1727653295,
+            commentCount: 0,
+            fieldIssueVersion: '1.0.x-dev',
+            fieldIssueStatus: 1,
+            fieldIssueCategory: 1,
+            fieldIssuePriority: 200,
+            fieldIssueComponent: 'Code',
+            fieldProjectId: '3060',
+            fieldProjectMachineName: 'ai_context',
+            bodyValue: null,
+            authorId: null,
+            fieldIssueFiles: [],
+            comments: [],
+        );
+    }
+
+    public function testPostsCommandAndReturnsResult(): void
+    {
+        $note = new \stdClass();
+        $note->id = 4242;
+
+        $gitLabClient = $this->createMock(GitLabClient::class);
+        $gitLabClient->expects(self::once())
+            ->method('postIssueNote')
+            ->with('project/ai_context', 3586157, '/do:fork')
+            ->willReturn($note);
+
+        $client = $this->createMock(Client::class);
+        $client->expects(self::never())->method('getNode');
+
+        $action = new PostWorkItemSlashCommandAction($client, $gitLabClient);
+        $result = $action('ai_context#3586157', '/do:fork');
+
+        self::assertSame('project/ai_context', $result->projectPath);
+        self::assertSame(3586157, $result->issueIid);
+        self::assertSame('/do:fork', $result->command);
+        self::assertSame(4242, $result->noteId);
+        self::assertSame(
+            'https://git.drupalcode.org/project/ai_context/-/work_items/3586157',
+            $result->workItemUrl(),
+        );
+    }
+
+    public function testResolvesBareNidViaDrupalOrg(): void
+    {
+        $note = new \stdClass();
+        $note->id = 7;
+
+        $client = $this->createMock(Client::class);
+        $client->expects(self::once())
+            ->method('getNode')
+            ->with('3586157')
+            ->willReturn(self::makeIssueNode());
+
+        $gitLabClient = $this->createMock(GitLabClient::class);
+        $gitLabClient->expects(self::once())
+            ->method('postIssueNote')
+            ->with('project/ai_context', 3586157, '/do:assign me')
+            ->willReturn($note);
+
+        $action = new PostWorkItemSlashCommandAction($client, $gitLabClient);
+        $result = $action('3586157', '/do:assign me');
+
+        self::assertSame('project/ai_context', $result->projectPath);
+        self::assertSame(3586157, $result->issueIid);
+    }
+
+    public function testAcceptsFullWorkItemUrl(): void
+    {
+        $note = new \stdClass();
+        $note->id = 99;
+
+        $gitLabClient = $this->createMock(GitLabClient::class);
+        $gitLabClient->expects(self::once())
+            ->method('postIssueNote')
+            ->with('project/ai_context', 3586157, '/do:label ~state::rtbc')
+            ->willReturn($note);
+
+        $client = $this->createMock(Client::class);
+
+        $action = new PostWorkItemSlashCommandAction($client, $gitLabClient);
+        $result = $action(
+            'https://git.drupalcode.org/project/ai_context/-/work_items/3586157',
+            '/do:label ~state::rtbc',
+        );
+
+        self::assertSame(99, $result->noteId);
+    }
+
+    public function testRejectsUnparseableRef(): void
+    {
+        $client = $this->createMock(Client::class);
+        $gitLabClient = $this->createMock(GitLabClient::class);
+        $gitLabClient->expects(self::never())->method('postIssueNote');
+
+        $action = new PostWorkItemSlashCommandAction($client, $gitLabClient);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $action('not-a-ref', '/do:fork');
+    }
+
+    public function testWrapsGitLabFailureWithHelpfulError(): void
+    {
+        $gitLabClient = $this->createMock(GitLabClient::class);
+        $gitLabClient->method('postIssueNote')->willThrowException(new \Exception('Not Found', 404));
+
+        $client = $this->createMock(Client::class);
+
+        $action = new PostWorkItemSlashCommandAction($client, $gitLabClient);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Drupal\.org issue queue/');
+        $action('ai_context#3586157', '/do:fork');
+    }
+}

--- a/tests/src/Action/GitLab/PostWorkItemSlashCommandActionTest.php
+++ b/tests/src/Action/GitLab/PostWorkItemSlashCommandActionTest.php
@@ -136,4 +136,41 @@ class PostWorkItemSlashCommandActionTest extends TestCase
         $this->expectExceptionMessageMatches('/Drupal\.org issue queue/');
         $action('ai_context#3586157', '/do:fork');
     }
+
+    public function testTrimsBareNidWithSurroundingWhitespace(): void
+    {
+        $note = new \stdClass();
+        $note->id = 11;
+
+        $client = $this->createMock(Client::class);
+        $client->expects(self::once())
+            ->method('getNode')
+            ->with('3586157')
+            ->willReturn(self::makeIssueNode());
+
+        $gitLabClient = $this->createMock(GitLabClient::class);
+        $gitLabClient->expects(self::once())
+            ->method('postIssueNote')
+            ->with('project/ai_context', 3586157, '/do:fork')
+            ->willReturn($note);
+
+        $action = new PostWorkItemSlashCommandAction($client, $gitLabClient);
+        $result = $action("  3586157\n", '/do:fork');
+
+        self::assertSame(11, $result->noteId);
+    }
+
+    public function testThrowsWhenGitLabResponseLacksId(): void
+    {
+        $gitLabClient = $this->createMock(GitLabClient::class);
+        $gitLabClient->method('postIssueNote')->willReturn(new \stdClass());
+
+        $client = $this->createMock(Client::class);
+
+        $action = new PostWorkItemSlashCommandAction($client, $gitLabClient);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/did not contain an id/');
+        $action('ai_context#3586157', '/do:fork');
+    }
 }

--- a/tests/src/GitLab/SlashCommandTest.php
+++ b/tests/src/GitLab/SlashCommandTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\DrupalOrg\Tests\GitLab;
+
+use mglaman\DrupalOrg\GitLab\SlashCommand;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SlashCommand::class)]
+class SlashCommandTest extends TestCase
+{
+    public function testFork(): void
+    {
+        self::assertSame('/do:fork', SlashCommand::fork());
+    }
+
+    public function testAccess(): void
+    {
+        self::assertSame('/do:access', SlashCommand::access());
+    }
+
+    public function testAssignMe(): void
+    {
+        self::assertSame('/do:assign me', SlashCommand::assign(['me']));
+    }
+
+    public function testAssignSingleUser(): void
+    {
+        self::assertSame('/do:assign @johndoe', SlashCommand::assign(['johndoe']));
+    }
+
+    public function testAssignStripsLeadingAt(): void
+    {
+        self::assertSame('/do:assign @johndoe', SlashCommand::assign(['@johndoe']));
+    }
+
+    public function testAssignMultipleUsers(): void
+    {
+        self::assertSame(
+            '/do:assign @alice @bob me',
+            SlashCommand::assign(['alice', '@bob', 'me']),
+        );
+    }
+
+    public function testUnassign(): void
+    {
+        self::assertSame('/do:unassign me', SlashCommand::unassign(['me']));
+    }
+
+    public function testReassign(): void
+    {
+        self::assertSame('/do:reassign @alice', SlashCommand::reassign(['alice']));
+    }
+
+    public function testLabelSingle(): void
+    {
+        self::assertSame('/do:label ~state::needsReview', SlashCommand::label(['state::needsReview']));
+    }
+
+    public function testLabelStripsLeadingTilde(): void
+    {
+        self::assertSame('/do:label ~state::rtbc', SlashCommand::label(['~state::rtbc']));
+    }
+
+    public function testLabelMultiple(): void
+    {
+        self::assertSame(
+            '/do:label ~state::needsReview ~priority::critical',
+            SlashCommand::label(['state::needsReview', '~priority::critical']),
+        );
+    }
+
+    public function testUnlabel(): void
+    {
+        self::assertSame('/do:unlabel ~state::needsWork', SlashCommand::unlabel(['state::needsWork']));
+    }
+
+    public function testRelabel(): void
+    {
+        self::assertSame('/do:relabel ~state::rtbc', SlashCommand::relabel(['state::rtbc']));
+    }
+
+    public function testAssignRejectsEmpty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        SlashCommand::assign([]);
+    }
+
+    public function testLabelRejectsEmpty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        SlashCommand::label([]);
+    }
+
+    public function testAssignRejectsBlankUser(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        SlashCommand::assign(['@']);
+    }
+
+    public function testLabelRejectsBlankLabel(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        SlashCommand::label(['~']);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds eight new `drupalorg` commands that post Drupal.org bot slash commands as comments on a GitLab work item: `issue:fork`, `issue:get-access`, `issue:assign`, `issue:unassign`, `issue:reassign`, `issue:label`, `issue:unlabel`, `issue:relabel`. Closes the gap where the CLI/skills had no programmatic way to create a fork, self-assign, or move an issue between `state::*` labels for projects whose queue lives at git.drupalcode.org.
- Adds `Client::postIssueNote()` to the GitLab HTTP client and falls back to `glab config get token --host git.drupalcode.org` when `DRUPALORG_GITLAB_TOKEN` is unset.
- Wires the new commands into `drupalorg-work-on-issue` (fork creation when missing, self-assign, hand-off label + unassign) and into the personal `drupalorg-mr-review` skill (verdict label).

Only applies to projects migrated to GitLab work items; classic Drupal.org issue queues are unaffected (bot is not present there).

Refs upstream docs: https://new.drupal.org/drupalorg/gitlab-custom-commands

## Test plan

- [x] `vendor/bin/phpcs src` clean
- [x] `vendor/bin/phpstan analyse src` clean
- [x] `vendor/bin/phpunit` — 149 tests, 505 assertions, all green (includes new `PostWorkItemSlashCommandActionTest` + `SlashCommandTest`)
- [ ] End-to-end smoke on a real work item project: `drupalorg issue:assign ai_context#<nid>`, confirm bot picks it up
- [ ] End-to-end: `drupalorg issue:fork <new-issue-ref>` on an issue without a fork, then `drupalorg issue:get-fork --no-cache` to confirm
- [ ] Negative: classic D.o queue NID should surface the helpful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)