### PR TITLE
fix: resolve release notes issue links for GitLab work item projects

### DIFF
--- a/src/Api/Action/Maintainer/GetMaintainerReleaseNotesAction.php
+++ b/src/Api/Action/Maintainer/GetMaintainerReleaseNotesAction.php
@@ -199,14 +199,14 @@ class GetMaintainerReleaseNotesAction implements ActionInterface
 
         // Fetch change records if we have a project ID.
         $changeRecords = [];
-        if ($projectId !== null) {
+        if ($projectId !== null && $projectId !== '') {
             $changeRecords = $drupalOrg->getChangeRecords($projectId, $ref2);
         }
 
         return new MaintainerReleaseNotesResult(
             ref1: $ref1,
             ref2: $ref2,
-            project: $project,
+            project: $machineName,
             categorizedChanges: $categorizedChanges,
             contributors: $users,
             nidList: $nidList,

--- a/src/Api/Action/Maintainer/GetMaintainerReleaseNotesAction.php
+++ b/src/Api/Action/Maintainer/GetMaintainerReleaseNotesAction.php
@@ -7,6 +7,7 @@ use mglaman\DrupalOrg\Action\ActionInterface;
 use mglaman\DrupalOrg\Client;
 use mglaman\DrupalOrg\CommitParser;
 use mglaman\DrupalOrg\DrupalOrg;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
 use mglaman\DrupalOrg\Result\Maintainer\MaintainerReleaseNotesResult;
 use Symfony\Component\Process\Process;
 
@@ -24,8 +25,10 @@ class GetMaintainerReleaseNotesAction implements ActionInterface
         5 => 'Plan',
     ];
 
-    public function __construct(private readonly Client $client)
-    {
+    public function __construct(
+        private readonly Client $client,
+        private readonly ?GitLabClient $gitLabClient = null,
+    ) {
     }
 
     public function __invoke(
@@ -96,23 +99,72 @@ class GetMaintainerReleaseNotesAction implements ActionInterface
         // Fetch data from Drupal.org concurrently.
         $drupalOrg = new DrupalOrg($this->client->getGuzzleClient());
         $nidList = array_values($nids);
-        $contributorsFromApi = $drupalOrg->getContributorsFromJsonApi($nidList);
-        $issueDetails = $drupalOrg->getIssueDetails($nidList);
-        $projectId = $drupalOrg->getProjectId($project);
+
+        // Projects migrated to GitLab work items report field_project_has_issue_queue
+        // as false. Work item iids are unique only within a project, so they must
+        // not be treated as global Drupal.org node IDs.
+        $projectEntity = $drupalOrg->getProject($project);
+        $projectId = $projectEntity?->nid;
+        $isGitLab = $projectEntity !== null && !$projectEntity->hasIssueQueue;
+        // The resolved machine name scopes GitLab work item URLs; fall back to the
+        // git-derived name when the project could not be looked up.
+        $machineName = ($projectEntity !== null && $projectEntity->machineName !== '')
+            ? $projectEntity->machineName
+            : $project;
+
+        // Contribution records are filtered by the issue's source link: a node URL
+        // for legacy issues, a work item URL for GitLab projects.
+        $sourceLinks = [];
+        foreach ($nidList as $nid) {
+            $sourceLinks[$nid] = $isGitLab
+                ? sprintf('https://git.drupalcode.org/project/%s/-/work_items/%s', $machineName, $nid)
+                : sprintf('https://www.drupal.org/node/%s', $nid);
+        }
+        $contributorsFromApi = $drupalOrg->getContributorsFromJsonApi($sourceLinks);
+
+        $issueDetails = $isGitLab ? [] : $drupalOrg->getIssueDetails($nidList);
+        $gitLabIssues = [];
+        if ($isGitLab) {
+            $gitLabClient = $this->gitLabClient ?? new GitLabClient();
+            $gitLabIssues = $gitLabClient->getIssuesByIid('project/' . $machineName, array_map('intval', $nidList));
+        }
 
         // Track all contributors across commits.
         $users = [];
+
+        // Map each issue ID to its resolved canonical URL.
+        $issueLinks = [];
 
         // Process commits into categorized changes.
         $categorizedChanges = [];
         foreach ($commits as $commit) {
             $nid = CommitParser::getNid($commit->title);
 
-            // Determine issue category.
+            // Determine issue category and link.
             $issueCategoryLabel = 'Misc';
-            if ($nid !== null && isset($issueDetails[$nid])) {
-                $issueCategory = $issueDetails[$nid]->fieldIssueCategory;
-                $issueCategoryLabel = self::CATEGORY_MAP[$issueCategory] ?? 'Misc';
+            if ($nid !== null) {
+                if ($isGitLab) {
+                    $issue = $gitLabIssues[(int) $nid] ?? null;
+                    $link = sprintf('https://www.drupal.org/project/%s/issues/%s', $machineName, $nid);
+                    if ($issue !== null) {
+                        $issueCategoryLabel = self::categoryFromGitLabLabels($issue->labels)
+                            ?? CommitParser::categoryFromConventionalCommit($commit->title)
+                            ?? 'Misc';
+                        if ($issue->webUrl !== '') {
+                            $link = $issue->webUrl;
+                        }
+                    } else {
+                        $issueCategoryLabel = CommitParser::categoryFromConventionalCommit($commit->title) ?? 'Misc';
+                    }
+                } elseif (isset($issueDetails[$nid])) {
+                    $issueCategory = $issueDetails[$nid]->fieldIssueCategory;
+                    $issueCategoryLabel = self::CATEGORY_MAP[$issueCategory] ?? 'Misc';
+                    $link = sprintf('https://www.drupal.org/node/%s', $nid);
+                } else {
+                    $issueCategoryLabel = CommitParser::categoryFromConventionalCommit($commit->title) ?? 'Misc';
+                    $link = sprintf('https://www.drupal.org/node/%s', $nid);
+                }
+                $issueLinks[$nid] = $link;
             }
 
             // Gather contributors: JSON:API first, then commit parsing, then email fallback.
@@ -159,7 +211,32 @@ class GetMaintainerReleaseNotesAction implements ActionInterface
             contributors: $users,
             nidList: $nidList,
             changeRecords: $changeRecords,
+            issueLinks: $issueLinks,
+            isGitLab: $isGitLab,
         );
+    }
+
+    /**
+     * Resolve an issue category from a GitLab `category::*` label.
+     *
+     * @param string[] $labels
+     */
+    private static function categoryFromGitLabLabels(array $labels): ?string
+    {
+        foreach ($labels as $label) {
+            $matches = [];
+            if (preg_match('/^category::(.+)$/i', $label, $matches) === 1) {
+                return match (strtolower(trim($matches[1]))) {
+                    'bug' => self::CATEGORY_MAP[1],
+                    'task' => self::CATEGORY_MAP[2],
+                    'feature' => self::CATEGORY_MAP[3],
+                    'support' => self::CATEGORY_MAP[4],
+                    'plan' => self::CATEGORY_MAP[5],
+                    default => null,
+                };
+            }
+        }
+        return null;
     }
 
     private function cleanCommitTitle(string $title): string
@@ -180,7 +257,18 @@ class GetMaintainerReleaseNotesAction implements ActionInterface
             return '';
         }
 
-        $remoteUrl = $process->getOutput();
+        $remoteUrl = trim($process->getOutput());
+
+        // GitLab-hosted projects (including those on work items) push to
+        // git.drupalcode.org/project/{name} or, for issue forks,
+        // git.drupalcode.org/issue/{name}-{nid}. Machine names use no hyphens,
+        // so the capture stops before the issue fork's "-{nid}" suffix.
+        if (str_contains($remoteUrl, 'git.drupalcode.org')) {
+            $matches = [];
+            if (preg_match('#git\.drupalcode\.org[:/](?:project|issue)/([a-z0-9_]+)#', $remoteUrl, $matches) === 1) {
+                return $matches[1];
+            }
+        }
 
         // Not a drupal.org project — use the directory name.
         if (strpos($remoteUrl, 'drupal.org') === false) {

--- a/src/Api/CommitParser.php
+++ b/src/Api/CommitParser.php
@@ -54,4 +54,24 @@ final class CommitParser
         }
         return null;
     }
+
+    /**
+     * Derive an issue category from a conventional-commit prefix.
+     *
+     * The optional scope matches any character except ")" so titles like
+     * "feat(CLI Tool):" and "chore(Project management):" resolve correctly.
+     */
+    public static function categoryFromConventionalCommit(string $title): ?string
+    {
+        $matches = [];
+        if (preg_match('/^(fix|feat|chore|docs|style|refactor|perf|test|build|ci)(?:\([^)]+\))?!?:\s/i', $title, $matches) !== 1) {
+            return null;
+        }
+        return match (strtolower($matches[1])) {
+            'fix' => 'Bug',
+            'feat' => 'Feature',
+            'chore' => 'Task',
+            default => null,
+        };
+    }
 }

--- a/src/Api/DrupalOrg.php
+++ b/src/Api/DrupalOrg.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\Utils;
 use mglaman\DrupalOrg\Entity\ChangeRecord;
 use mglaman\DrupalOrg\Entity\IssueNode;
+use mglaman\DrupalOrg\Entity\Project;
 
 final class DrupalOrg
 {
@@ -43,14 +44,41 @@ final class DrupalOrg
     }
 
     /**
+     * Get the project entity (nid + issue queue type) from a machine name.
+     *
+     * Reads field_project_has_issue_queue so callers can tell whether issues
+     * live on the legacy Drupal.org queue or on GitLab work items.
+     */
+    public function getProject(string $machineName): ?Project
+    {
+        try {
+            $url = sprintf(
+                'https://www.drupal.org/api-d7/node.json?field_project_machine_name=%s',
+                urlencode($machineName)
+            );
+            $response = $this->client->request('GET', $url);
+            $data = \json_decode((string) $response->getBody());
+            if ($data === null || !isset($data->list) || count($data->list) === 0) {
+                return null;
+            }
+            return Project::fromStdClass($data->list[0]);
+        } catch (RequestException) {
+            return null;
+        } catch (\JsonException) {
+            return null;
+        }
+    }
+
+    /**
      * Fetch contributors for multiple issues concurrently using promises.
      *
-     * @param list<string> $nids Array of issue node IDs
-     * @return array<string, list<string>> Associative array mapping nid => array of contributor display names
+     * @param array<string, string> $sourceLinks Map of id => contribution source URI
+     *   (a Drupal.org node URL for legacy issues, or a GitLab work item URL).
+     * @return array<string, list<string>> Map of id => contributor display names
      */
-    public function getContributorsFromJsonApi(array $nids): array
+    public function getContributorsFromJsonApi(array $sourceLinks): array
     {
-        if ($nids === []) {
+        if ($sourceLinks === []) {
             return [];
         }
 
@@ -58,26 +86,26 @@ final class DrupalOrg
 
         try {
             $promises = [];
-            foreach ($nids as $nid) {
+            foreach ($sourceLinks as $id => $sourceLink) {
                 $url = sprintf(
-                    'https://www.drupal.org/jsonapi/node/contribution_record?filter[field_source_link.uri]=https://www.drupal.org/node/%s&filter[field_contributors.field_credit_this_contributor]=1&include=field_contributors.field_contributor_user&fields[node--contribution_record]=field_contributors&fields[paragraph--contributor]=field_contributor_user,field_credit_this_contributor&fields[user--user]=display_name',
-                    urlencode($nid)
+                    'https://www.drupal.org/jsonapi/node/contribution_record?filter[field_source_link.uri]=%s&filter[field_contributors.field_credit_this_contributor]=1&include=field_contributors.field_contributor_user&fields[node--contribution_record]=field_contributors&fields[paragraph--contributor]=field_contributor_user,field_credit_this_contributor&fields[user--user]=display_name',
+                    urlencode($sourceLink)
                 );
-                $promises[$nid] = $this->client->requestAsync('GET', $url);
+                $promises[$id] = $this->client->requestAsync('GET', $url);
             }
 
             $results = Utils::settle($promises)->wait();
 
-            foreach ($results as $nid => $result) {
+            foreach ($results as $id => $result) {
                 if ($result['state'] === PromiseInterface::FULFILLED) {
                     try {
                         $data = \json_decode((string) $result['value']->getBody(), false, 512, JSON_THROW_ON_ERROR);
-                        $contributors[$nid] = $this->extractContributorsFromJsonApiResponse($data);
+                        $contributors[$id] = $this->extractContributorsFromJsonApiResponse($data);
                     } catch (\JsonException) {
-                        $contributors[$nid] = [];
+                        $contributors[$id] = [];
                     }
                 } else {
-                    $contributors[$nid] = [];
+                    $contributors[$id] = [];
                 }
             }
         } catch (\Throwable) {

--- a/src/Api/GitLab/Client.php
+++ b/src/Api/GitLab/Client.php
@@ -3,7 +3,10 @@
 namespace mglaman\DrupalOrg\GitLab;
 
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\Utils;
 use GuzzleRetry\GuzzleRetryMiddleware;
+use mglaman\DrupalOrg\GitLab\Entity\GitLabIssue;
 use Symfony\Component\Process\Process;
 
 class Client
@@ -221,6 +224,45 @@ class Client
     {
         $result = $this->get('projects/' . urlencode($projectPath) . '/issues', $params);
         return is_array($result) ? $result : [];
+    }
+
+    /**
+     * Fetch multiple work items in one project concurrently, keyed by iid.
+     *
+     * Work item iids are unique only within a project, so this fetches each iid
+     * from the same project path. Failed or non-decodable responses map to null.
+     *
+     * @param int[] $iids
+     * @return array<int, GitLabIssue|null>
+     */
+    public function getIssuesByIid(string $projectPath, array $iids): array
+    {
+        if ($iids === []) {
+            return [];
+        }
+
+        $path = 'projects/' . urlencode($projectPath) . '/issues/';
+        $issues = [];
+        $promises = [];
+        foreach ($iids as $iid) {
+            $promises[$iid] = $this->client->requestAsync('GET', $path . $iid);
+        }
+
+        $results = Utils::settle($promises)->wait();
+        foreach ($results as $iid => $result) {
+            if ($result['state'] !== PromiseInterface::FULFILLED) {
+                $issues[$iid] = null;
+                continue;
+            }
+            try {
+                $data = \json_decode((string) $result['value']->getBody(), false, 512, JSON_THROW_ON_ERROR);
+                $issues[$iid] = GitLabIssue::fromStdClass($data);
+            } catch (\JsonException) {
+                $issues[$iid] = null;
+            }
+        }
+
+        return $issues;
     }
 
     /**

--- a/src/Api/Result/Maintainer/MaintainerReleaseNotesResult.php
+++ b/src/Api/Result/Maintainer/MaintainerReleaseNotesResult.php
@@ -12,6 +12,7 @@ class MaintainerReleaseNotesResult implements ResultInterface
      * @param array<string, int> $contributors username => commit count
      * @param list<string> $nidList
      * @param ChangeRecord[] $changeRecords
+     * @param array<string, string> $issueLinks nid => resolved issue URL
      */
     public function __construct(
         public readonly string $ref1,
@@ -21,6 +22,8 @@ class MaintainerReleaseNotesResult implements ResultInterface
         public readonly array $contributors,
         public readonly array $nidList,
         public readonly array $changeRecords,
+        public readonly array $issueLinks = [],
+        public readonly bool $isGitLab = false,
     ) {
     }
 
@@ -37,6 +40,8 @@ class MaintainerReleaseNotesResult implements ResultInterface
                 static fn(ChangeRecord $r) => ['title' => $r->title, 'url' => $r->url],
                 $this->changeRecords
             ),
+            'issue_links' => $this->issueLinks,
+            'is_gitlab' => $this->isGitLab,
         ];
     }
 }

--- a/src/Cli/Command/Maintainer/ReleaseNotes.php
+++ b/src/Cli/Command/Maintainer/ReleaseNotes.php
@@ -103,7 +103,7 @@ class ReleaseNotes extends Command
         switch ($format) {
             case 'json':
                 $this->stdOut->writeln(
-                    json_encode($result->categorizedChanges, JSON_PRETTY_PRINT)
+                    json_encode($result, JSON_PRETTY_PRINT)
                 );
                 break;
 
@@ -144,7 +144,7 @@ class ReleaseNotes extends Command
                     $this->stdOut->writeln(sprintf('#### %s', $changeCategory));
                     $this->stdOut->writeln('');
                     foreach ($changeCategoryItems as $nid => $change) {
-                        $link = $result->issueLinks[$nid] ?? null;
+                        $link = $result->isGitLab ? ($result->issueLinks[$nid] ?? null) : null;
                         $this->stdOut->writeln(sprintf('* %s', $this->formatLine($change, $format, $link)));
                     }
                     $this->stdOut->writeln('');
@@ -204,7 +204,7 @@ class ReleaseNotes extends Command
                     );
                     $this->stdOut->writeln('<ul>');
                     foreach ($changeCategoryItems as $nid => $change) {
-                        $link = $result->issueLinks[$nid] ?? null;
+                        $link = $result->isGitLab ? ($result->issueLinks[$nid] ?? null) : null;
                         $this->stdOut->writeln(
                             sprintf('  <li>%s</li>', $this->formatLine($change, $format, $link))
                         );
@@ -246,18 +246,22 @@ class ReleaseNotes extends Command
 
     protected function formatLine(string $value, string $format, ?string $link = null): string
     {
-        // Legacy issues fall back to the global node URL; GitLab work items and
-        // resolved issues pass an explicit project-scoped link.
-        $baseUrl = $link ?? 'https://www.drupal.org/node/$1';
-
-        if ($format === 'html') {
-            $replacement = sprintf('<a href="%s">#$1</a>', $baseUrl);
-        } elseif ($format === 'markdown' || $format === 'md') {
-            $replacement = sprintf('[#$1](%s)', $baseUrl);
-        } else {
-            $replacement = '#$1';
-        }
-
-        return preg_replace('/#(\d+)/S', $replacement, $value);
+        // A resolved $link (GitLab work item or canonical issue URL) overrides the
+        // default; otherwise each "#nid" links to its own global node. The URL is
+        // emitted via a callback, never interpolated into the regex replacement.
+        return preg_replace_callback(
+            '/#(\d+)/S',
+            static function (array $matches) use ($format, $link): string {
+                $url = $link ?? sprintf('https://www.drupal.org/node/%s', $matches[1]);
+                if ($format === 'html') {
+                    return sprintf('<a href="%s">#%s</a>', htmlspecialchars($url, ENT_QUOTES), $matches[1]);
+                }
+                if ($format === 'markdown' || $format === 'md') {
+                    return sprintf('[#%s](%s)', $matches[1], $url);
+                }
+                return '#' . $matches[1];
+            },
+            $value
+        ) ?? $value;
     }
 }

--- a/src/Cli/Command/Maintainer/ReleaseNotes.php
+++ b/src/Cli/Command/Maintainer/ReleaseNotes.php
@@ -143,8 +143,9 @@ class ReleaseNotes extends Command
                 foreach ($result->categorizedChanges as $changeCategory => $changeCategoryItems) {
                     $this->stdOut->writeln(sprintf('#### %s', $changeCategory));
                     $this->stdOut->writeln('');
-                    foreach ($changeCategoryItems as $change) {
-                        $this->stdOut->writeln(sprintf('* %s', $this->formatLine($change, $format)));
+                    foreach ($changeCategoryItems as $nid => $change) {
+                        $link = $result->issueLinks[$nid] ?? null;
+                        $this->stdOut->writeln(sprintf('* %s', $this->formatLine($change, $format, $link)));
                     }
                     $this->stdOut->writeln('');
                 }
@@ -202,9 +203,10 @@ class ReleaseNotes extends Command
                         sprintf('<h4>%s</h4>', $changeCategory)
                     );
                     $this->stdOut->writeln('<ul>');
-                    foreach ($changeCategoryItems as $change) {
+                    foreach ($changeCategoryItems as $nid => $change) {
+                        $link = $result->issueLinks[$nid] ?? null;
                         $this->stdOut->writeln(
-                            sprintf('  <li>%s</li>', $this->formatLine($change, $format))
+                            sprintf('  <li>%s</li>', $this->formatLine($change, $format, $link))
                         );
                     }
                     $this->stdOut->writeln('</ul>');
@@ -242,9 +244,11 @@ class ReleaseNotes extends Command
         return sprintf($replacement, $userAlias, $user);
     }
 
-    protected function formatLine(string $value, string $format): string
+    protected function formatLine(string $value, string $format, ?string $link = null): string
     {
-        $baseUrl = 'https://www.drupal.org/node/$1';
+        // Legacy issues fall back to the global node URL; GitLab work items and
+        // resolved issues pass an explicit project-scoped link.
+        $baseUrl = $link ?? 'https://www.drupal.org/node/$1';
 
         if ($format === 'html') {
             $replacement = sprintf('<a href="%s">#$1</a>', $baseUrl);

--- a/tests/src/Action/Maintainer/GetMaintainerReleaseNotesActionTest.php
+++ b/tests/src/Action/Maintainer/GetMaintainerReleaseNotesActionTest.php
@@ -9,6 +9,8 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use mglaman\DrupalOrg\Action\Maintainer\GetMaintainerReleaseNotesAction;
 use mglaman\DrupalOrg\Client;
+use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
+use mglaman\DrupalOrg\GitLab\Entity\GitLabIssue;
 use mglaman\DrupalOrg\Result\Maintainer\MaintainerReleaseNotesResult;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -102,11 +104,11 @@ class GetMaintainerReleaseNotesActionTest extends TestCase
 
     public function testInvokeRef2HeadAllowed(): void
     {
-        // MockHandler responses: contributors for NID 1234567, issue details for NID 1234567, projectId query
+        // Request order: project lookup, contributors, issue details.
         $client = $this->makeClientWithMockResponses([
+            new Response(200, [], json_encode(['list' => []])),          // project lookup (null → legacy)
             new Response(200, [], json_encode(['data' => []])),          // contributors (empty)
             new Response(200, [], json_encode(['nid' => '1234567', 'title' => 'Fix the thing', 'field_issue_category' => 1])), // issue details
-            new Response(200, [], json_encode(['list' => []])),           // projectId (null)
         ]);
 
         $action = new GetMaintainerReleaseNotesAction($client);
@@ -120,11 +122,11 @@ class GetMaintainerReleaseNotesActionTest extends TestCase
 
     public function testInvoke(): void
     {
-        // MockHandler responses: contributors, issue details, projectId
+        // Request order: project lookup (null → legacy, no change records), contributors, issue details.
         $client = $this->makeClientWithMockResponses([
+            new Response(200, [], json_encode(['list' => []])),          // project lookup (null → legacy)
             new Response(200, [], json_encode(['data' => []])),          // contributors (empty)
             new Response(200, [], json_encode(['nid' => '1234567', 'title' => 'Fix the thing', 'field_issue_category' => 1])), // issue details
-            new Response(200, [], json_encode(['list' => []])),           // projectId (null → skip change records)
         ]);
 
         $action = new GetMaintainerReleaseNotesAction($client);
@@ -145,12 +147,75 @@ class GetMaintainerReleaseNotesActionTest extends TestCase
         self::assertSame([], $result->changeRecords);
     }
 
+    public function testInvokeGitLabWorkItem(): void
+    {
+        // Request order: project lookup (GitLab), contributors, change records.
+        // GitLab work item data comes from the injected GitLab client.
+        $client = $this->makeClientWithMockResponses([
+            new Response(200, [], json_encode(['list' => [[
+                'nid' => '2431121',
+                'field_project_machine_name' => 'canvas',
+                'field_project_has_issue_queue' => false,
+            ]]])),                                              // project lookup (GitLab)
+            new Response(200, [], json_encode(['data' => []])), // contributors (empty)
+            new Response(200, [], json_encode(['list' => []])), // change records (none)
+        ]);
+
+        $gitLabClient = $this->createMock(GitLabClient::class);
+        $gitLabClient->method('getIssuesByIid')->willReturn([
+            1234567 => GitLabIssue::fromStdClass((object) [
+                'iid' => 1234567,
+                'title' => 'Fix the thing',
+                'labels' => ['category::bug'],
+                'web_url' => 'https://git.drupalcode.org/project/canvas/-/work_items/1234567',
+            ]),
+        ]);
+
+        $action = new GetMaintainerReleaseNotesAction($client, $gitLabClient);
+        $result = $action(self::$gitRepo, self::$tmpDir, '1.0.0', '1.1.0');
+
+        self::assertTrue($result->isGitLab);
+        // Category resolved from the category::bug GitLab label.
+        self::assertArrayHasKey('Bug', $result->categorizedChanges);
+        // Link uses the work item web_url, not a global node URL.
+        self::assertSame(
+            'https://git.drupalcode.org/project/canvas/-/work_items/1234567',
+            $result->issueLinks[1234567]
+        );
+    }
+
+    public function testInvokeGitLabWorkItemFallsBackToCanonicalLink(): void
+    {
+        $client = $this->makeClientWithMockResponses([
+            new Response(200, [], json_encode(['list' => [[
+                'nid' => '2431121',
+                'field_project_machine_name' => 'canvas',
+                'field_project_has_issue_queue' => false,
+            ]]])),
+            new Response(200, [], json_encode(['data' => []])),
+            new Response(200, [], json_encode(['list' => []])),
+        ]);
+
+        // GitLab fetch fails for the iid (null), so the canonical link is used.
+        $gitLabClient = $this->createMock(GitLabClient::class);
+        $gitLabClient->method('getIssuesByIid')->willReturn([1234567 => null]);
+
+        $action = new GetMaintainerReleaseNotesAction($client, $gitLabClient);
+        $result = $action(self::$gitRepo, self::$tmpDir, '1.0.0', '1.1.0');
+
+        self::assertTrue($result->isGitLab);
+        self::assertSame(
+            'https://www.drupal.org/project/canvas/issues/1234567',
+            $result->issueLinks[1234567]
+        );
+    }
+
     public function testJsonSerialize(): void
     {
         $client = $this->makeClientWithMockResponses([
+            new Response(200, [], json_encode(['list' => []])),
             new Response(200, [], json_encode(['data' => []])),
             new Response(200, [], json_encode(['nid' => '1234567', 'title' => 'Fix the thing', 'field_issue_category' => 0])),
-            new Response(200, [], json_encode(['list' => []])),
         ]);
 
         $action = new GetMaintainerReleaseNotesAction($client);

--- a/tests/src/Action/Maintainer/GetMaintainerReleaseNotesActionTest.php
+++ b/tests/src/Action/Maintainer/GetMaintainerReleaseNotesActionTest.php
@@ -13,6 +13,7 @@ use mglaman\DrupalOrg\GitLab\Client as GitLabClient;
 use mglaman\DrupalOrg\GitLab\Entity\GitLabIssue;
 use mglaman\DrupalOrg\Result\Maintainer\MaintainerReleaseNotesResult;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
@@ -231,5 +232,40 @@ class GetMaintainerReleaseNotesActionTest extends TestCase
         self::assertIsArray($decoded['contributors']);
         self::assertIsArray($decoded['nid_list']);
         self::assertIsArray($decoded['change_records']);
+        self::assertIsArray($decoded['issue_links']);
+        self::assertFalse($decoded['is_gitlab']);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function gitLabRemoteProvider(): array
+    {
+        return [
+            'https project' => ['https://git.drupalcode.org/project/canvas.git', 'canvas'],
+            'ssh project' => ['git@git.drupalcode.org:project/canvas.git', 'canvas'],
+            'issue fork strips nid' => ['https://git.drupalcode.org/issue/canvas-3001234.git', 'canvas'],
+            'machine name with underscore' => ['https://git.drupalcode.org/project/some_module.git', 'some_module'],
+        ];
+    }
+
+    #[DataProvider('gitLabRemoteProvider')]
+    public function testGetProjectNameFromGitLabRemote(string $remoteUrl, string $expected): void
+    {
+        $dir = sys_get_temp_dir() . '/drupalorg-cli-remote-' . uniqid();
+        mkdir($dir);
+        $run = static function (array $cmd) use ($dir): void {
+            (new Process($cmd, $dir))->mustRun();
+        };
+        $run(['git', 'init']);
+        $run(['git', 'remote', 'add', 'origin', $remoteUrl]);
+
+        $action = new GetMaintainerReleaseNotesAction($this->createMock(Client::class));
+        $method = new \ReflectionMethod($action, 'getProjectName');
+        $projectName = $method->invoke($action, $dir);
+
+        (new Process(['rm', '-rf', $dir]))->run();
+
+        self::assertSame($expected, $projectName);
     }
 }

--- a/tests/src/CommitParserTest.php
+++ b/tests/src/CommitParserTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace mglaman\DrupalOrg\Tests;
+
+use mglaman\DrupalOrg\CommitParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CommitParser::class)]
+class CommitParserTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string, 1: ?string}>
+     */
+    public static function conventionalCommitProvider(): array
+    {
+        return [
+            'fix maps to Bug' => ['fix: #123 correct the thing', 'Bug'],
+            'feat maps to Feature' => ['feat: add a new thing', 'Feature'],
+            'chore maps to Task' => ['chore: tidy up', 'Task'],
+            'scope with spaces' => ['feat(CLI Tool): add a flag', 'Feature'],
+            'scope with spaces and bang' => ['chore(Project management)!: drop support', 'Task'],
+            'unmapped type' => ['docs: update readme', null],
+            'not conventional' => ['Issue #123: fix the thing by user:', null],
+        ];
+    }
+
+    #[DataProvider('conventionalCommitProvider')]
+    public function testCategoryFromConventionalCommit(string $title, ?string $expected): void
+    {
+        self::assertSame($expected, CommitParser::categoryFromConventionalCommit($title));
+    }
+}


### PR DESCRIPTION
## Context

`maintainer:release-notes` (`rn`, `mrn`) pulled a numeric ID out of each commit title and treated it as a **global Drupal.org node ID** — linking to `drupal.org/node/{id}`, fetching the category from `api-d7/node/{id}.json`, and filtering contributors by the node URL.

That is wrong for projects migrated to **GitLab work items**. A work item iid is unique only within its project, so `drupal.org/node/{iid}` points at an unrelated node (or 404s), categories come back wrong, and contributor lookups miss. Test case: `canvas` 1.5.0 from 1.4.1 — every issue link was broken.

This ports the fix already shipped in the web version, `drupal-mrn` ([commit d42f463](https://github.com/mglaman/drupal-mrn/commit/d42f4638e4b7c535bd5d050a27d148dc4e3276f6)), to the CLI's Action / Result / Command layering.

## What changed

- **Detect GitLab projects** via `field_project_has_issue_queue` on the project node.
- **Issue link** — prefer the work item `web_url` (`git.drupalcode.org/project/{p}/-/work_items/{iid}`); fall back to canonical `drupal.org/project/{p}/issues/{iid}`. Never a global node URL.
- **Category** — from the `category::*` GitLab label, then a conventional-commit prefix (`fix:`→Bug, `feat:`→Feature, `chore:`→Task), then Misc. The conventional-commit fallback now applies to legacy projects too.
- **Contributors** — filter `contribution_record` by the work item URL.
- **Project name resolution** — parse `git.drupalcode.org/project/{name}` (and issue-fork) remotes, which previously fell through to the directory name and broke GitLab detection.

### Files
- `GitLab/Client.php` — `getIssuesByIid()` concurrent work item fetch
- `DrupalOrg.php` — `getProject()`; `getContributorsFromJsonApi()` takes a keyed `id => sourceURI` map
- `CommitParser.php` — `categoryFromConventionalCommit()`
- `GetMaintainerReleaseNotesAction.php` — GitLab branch, `issueLinks` map, `isGitLab` flag, remote parsing
- `MaintainerReleaseNotesResult.php` — `issueLinks` + `isGitLab`
- `Cli/Command/Maintainer/ReleaseNotes.php` — link per-issue from the map

## Verification

- `vendor/bin/phpunit` (160 tests), `phpcs`, `phpstan` (level 6) all green. New unit cases: GitLab `web_url`, GitLab 404→canonical fallback, conventional-commit data provider.
- Smoke test against a real `canvas` clone:
  ```
  drupalorg mrn 1.4.1 1.5.0 --format=md
  ```
  Links now resolve to `git.drupalcode.org/project/canvas/-/work_items/{iid}`. Reference issues categorize as in drupal-mrn: `#3576410`→Bug, `#3555239`→Bug (label wins over the `chore` prefix), `#3588438`→Task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)